### PR TITLE
Start fresh session functionality to be used from plugin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6686,9 +6686,9 @@
       }
     },
     "session-management-js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/session-management-js/-/session-management-js-0.0.1.tgz",
-      "integrity": "sha512-NPgh8xJjS2JPS33YzzfUQU9rcnbRjUf2/MHC7Xk+EdTU/iZRA/0JHInzEFgJaInBU5AuxFkYxFkimEYBuNsrXg=="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/session-management-js/-/session-management-js-0.0.2.tgz",
+      "integrity": "sha512-cWHmB6LKjA1y/8wILryUfu71mkuyhLvGxvAHtMagviGZT6qWe1KK3akZzo34dK8NBMG4CnDHhxh4STIXUkmvEQ=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "private": true,
   "scripts": {
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "rxjs": "^6.5.2",
-    "session-management-js": "^0.0.1"
+    "session-management-js": "^0.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,15 @@ import 'session-management-js';
 import Recorder from './recorder/recorder.js';
 
 function init(options) {
-  return new Recorder(options);
+  window['Recorder'] = new Recorder(options);
+
+  return window.Recorder;
 }
 
-export {init};
+document.addEventListener('recorderLibraryVersionRequested', function (event) {
+  document.dispatchEvent(new CustomEvent('recorderLibraryVersionProvisioned', {
+    detail: window.Recorder.getVersion()
+  }));
+});
+
+export { init };


### PR DESCRIPTION
Changes made in order to allow the chrome plugin to use the library. 

* Talk with plugin through events. 
Also added `Recorder` instance to window. Plugin will use it for recreating sessions. 
* `startFreshSession` method which stops the websocket, calls session-management for generating a new cookie (session) and start again. 

https://www.youtube.com/watch?v=SlR8P33bEj0&feature=youtu.be

Session-management PR: https://github.com/TestRigor/session-management/pull/7
Plugin PR: https://github.com/TestRigor/recorder/pull/1
Ticket: https://www.pivotaltracker.com/story/show/167926177