### PR TITLE
Reduced throttleTime on click events

### DIFF
--- a/src/recorder/events/handlers/click-event-handler.js
+++ b/src/recorder/events/handlers/click-event-handler.js
@@ -6,7 +6,7 @@ export default class ClickEventHandler {
   constructor() {
     this._events = fromEvent(document, 'click')
       .pipe(
-        throttleTime(1000),
+        throttleTime(200),
         map((event) => new ElementClicked(event))
       );
   }


### PR DESCRIPTION
Current value of 1000ms is too high, it fails to record legitimate click events