### PR TITLE
Get rect properties from boundingClientRect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -8,12 +8,14 @@ export default class Event {
     if (!this.isHtmlOrBody(element)) {
       this.innerText = element.innerText;
     }
+    let rect = element.getBoundingClientRect() || {};
+
+    this.clientHeight = rect.height || element.clientHeight;
+    this.clientWidth = rect.width || element.clientWidth;
+    this.clientTop = rect.top || element.clientTop;
+    this.clientLeft = rect.left || element.clientLeft;
     this.className = element.className;
     this.resourceId = element.id;
-    this.clientHeight = element.clientHeight;
-    this.clientWidth = element.clientWidth;
-    this.clientTop = element.clientTop;
-    this.clientLeft = element.clientLeft;
     this.offsetHeight = element.offsetHeight;
     this.offsetWidth = element.offsetWidth;
     this.offsetLeft = element.offsetLeft;


### PR DESCRIPTION
Use `element.getBoundingClientRect()` to get the element top, left, width and height instead of clientTop, clientLeft, clientHeight and clientWidth. See [here](https://stackoverflow.com/questions/45045306/getting-incorrect-values-for-elements-position-from-clientleft-clienttop-offs) and [here](https://stackoverflow.com/questions/1350581/how-to-get-an-elements-top-position-relative-to-the-browsers-viewport)
![Screenshot from 2019-11-18 16-52-44](https://user-images.githubusercontent.com/54808102/69084874-e7f5cc00-0a23-11ea-83ed-b5668d753f3c.png)
