### PR TITLE
Record labels asociated with inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -1,3 +1,5 @@
+import getLabelForElement from '../helpers/label-finder';
+
 export default class Event {
   constructor(event) {
     const element = event['srcElement'];
@@ -8,7 +10,7 @@ export default class Event {
     if (!this.isHtmlOrBody(element)) {
       this.innerText = element.innerText;
     }
-    let rect = element.getBoundingClientRect() || {};
+    let rect = element.getBoundingClientRect ? element.getBoundingClientRect() || {} : {};
 
     this.clientHeight = rect.height || element.clientHeight;
     this.clientWidth = rect.width || element.clientWidth;
@@ -35,6 +37,7 @@ export default class Event {
     this.windowHeight = window.innerHeight;
     this.windowWidth = window.innerWidth;
     this.url = location.href;
+    this.label = getLabelForElement(element);
   }
 
   isHtmlOrBody(element) {

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -1,0 +1,52 @@
+import { contains, doSidesIntersect, distanceBetweenLeftCenterPoints } from './rect-helper';
+
+const labelTags = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd', 'bdo', 'map',
+  'q', 'span', 'sub', 'sup', 'label', 'text'];
+
+function possiblyRelated(element, label) {
+  const elementRect = element.getBoundingClientRect();
+  const labelRect = label.getBoundingClientRect();
+
+  if (contains(elementRect, labelRect) || contains(labelRect, elementRect)) {
+    return true;
+  }
+
+  if (!(labelRect.x < elementRect.x || labelRect.y < elementRect.y)) {
+    return false;
+  }
+
+  return doSidesIntersect(elementRect, labelRect);
+}
+
+export default function getLabelForElement(element) {
+  try {
+    if (element.tagName && (element.tagName.toLowerCase() !== 'input' ||
+                            element.tagName.toLowerCase() !== 'select' ||
+                            element.tagName.toLowerCase() !== 'textarea')) {
+      return '';
+    }
+
+    let labelElement = document.querySelector(`label[for="${element.id}"]`);
+
+    if (labelElement == null && element.getBoundingClientRect) {
+      const labelElements = document.querySelectorAll(labelTags.join() + ',.label');
+
+      let possibleLabels = Array.from(labelElements)
+        .filter(label => label.getBoundingClientRect && possiblyRelated(element, label));
+
+      let shortestDistance = null;
+
+      for (const possibleLabel of possibleLabels) {
+        let distance = distanceBetweenLeftCenterPoints(element, possibleLabel);
+
+        if (shortestDistance === null || distance < shortestDistance) {
+          shortestDistance = distance;
+          labelElement = possibleLabel;
+        }
+      }
+    }
+    return labelElement != null ? labelElement.innerText : '';
+  } catch (error) {
+    return '';
+  }
+}

--- a/src/recorder/helpers/rect-helper.js
+++ b/src/recorder/helpers/rect-helper.js
@@ -1,0 +1,31 @@
+function valueInRange(value, min, max) {
+  return (value >= min) && (value <= max);
+}
+
+function contains(rect, otherRect) {
+  return valueInRange(otherRect.x, rect.x, rect.x + rect.width) &&
+    valueInRange(otherRect.x + otherRect.width, rect.x, rect.x + rect.width) &&
+    valueInRange(otherRect.y, rect.y, rect.y + rect.height) &&
+    valueInRange(otherRect.y + otherRect.height, rect.y, rect.y + rect.height);
+}
+
+function doSidesIntersect(rect, otherRect) {
+  const horizontalIntersection = (rect.x + rect.width >= otherRect.x) ||
+    (otherRect.x + otherRect.width >= rect.x);
+  const verticalIntersection = rect.y + rect.height >= otherRect.y ||
+    (otherRect.y + otherRect.height >= rect.y);
+
+  return horizontalIntersection || verticalIntersection;
+}
+
+function distanceBetweenLeftCenterPoints(element, otherElement) {
+  const rect = element.getBoundingClientRect();
+  const otherRect = otherElement.getBoundingClientRect();
+  const rectMidy = rect.bottom + rect.height / 2;
+  const otherRectMidY = otherRect.bottom + otherRect.height / 2;
+  const distanceSquared = Math.pow(rect.x - otherRect.x, 2) + Math.pow(rectMidy - otherRectMidY, 2);
+
+  return Math.sqrt(distanceSquared);
+}
+
+export { contains, doSidesIntersect, distanceBetweenLeftCenterPoints };


### PR DESCRIPTION
If there is a label with the correct `for` attrbute pick that one.
If not, pick the closest possibly related label, with distance calculated from the left side.
A label is possibly related if:
a) the label's rect contains the element's rect or viceversa, or 
b) the label is positioned to the left or on top of the element, or
c) the label's rect is touching sides with the element's rect (this is to avoid discarding labels to the right or bottom of the element if they are very very close, this wouldn't matter for labels on top or to the left)
