### PR TITLE
Fix object className for use tag inside svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -17,7 +17,7 @@ export default class Event {
     this.clientWidth = rect.width || element.clientWidth;
     this.clientTop = rect.top || element.clientTop;
     this.clientLeft = rect.left || element.clientLeft;
-    this.className = element.className;
+    this.className = (typeof element.className === 'string') ? element.className : '';
     this.resourceId = element.id;
     this.offsetHeight = element.offsetHeight;
     this.offsetWidth = element.offsetWidth;


### PR DESCRIPTION
```
{"priority":-100,"event":{"clientHeight":24,"clientWidth":24,"clientTop":138,"clientLeft":19.5,"className":{},"resourceId":"","scrollHeight":0,"scrollWidth":0,"scrollTop":0,"scrollLeft":0,"tagName":"use","xpath":"/html[1]/body[1]/my-app[1]/app-app-container[1]/div[1]/div[1]/n2p-left-side-nav[1]/div[1]/div[3]/n2p-svg[1]/svg[1]/use[1]","windowScrollY":0,"windowScrollX":0,"windowHeight":969,"windowWidth":1092,"url":"https://app.net2phone.com/dashboard","label":"","customTag":"use","type":"click","clickX":34,"clickY":139}}
```
POST to recorder service returned with 400 because the className of use tag is `{}`. 