### PR TITLE
Record events from iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event-listener.js
+++ b/src/recorder/events/event-listener.js
@@ -5,12 +5,25 @@ import {ClickEventHandler, InputEventHandler, DragEventHandler,
   NavigateEventHandler, EnterKeyPressEventHandler} from './handlers';
 
 export default class EventListener {
-  constructor(options) {
-    this._clickEventHandler = new ClickEventHandler(options);
-    this._inputEventHandler = new InputEventHandler(options);
-    this._dragEventHandler = new DragEventHandler(options);
-    this._navigateEventHandler = new NavigateEventHandler();
-    this._enterKeyPressEventHandler = new EnterKeyPressEventHandler(options);
+  constructor(options, dispatchEvents) {
+    let documents = [document],
+      windows = [window];
+
+    if (dispatchEvents) {
+      let iframes = document.getElementsByTagName('iframe');
+
+      for (let i = 0; i < iframes.length; i++) {
+        if (iframes[i].contentDocument) {
+          documents.push(iframes[i].contentDocument);
+          windows.push(iframes[i].contentWindow);
+        }
+      }
+    }
+    this._clickEventHandler = new ClickEventHandler(documents, options);
+    this._inputEventHandler = new InputEventHandler(documents, options);
+    this._dragEventHandler = new DragEventHandler(documents, options);
+    this._navigateEventHandler = new NavigateEventHandler(windows);
+    this._enterKeyPressEventHandler = new EnterKeyPressEventHandler(documents, options);
     this._events = from([
       this._clickEventHandler.events,
       this._inputEventHandler.events,

--- a/src/recorder/events/handlers/click-event-handler.js
+++ b/src/recorder/events/handlers/click-event-handler.js
@@ -3,8 +3,8 @@ import {map, throttleTime} from 'rxjs/operators';
 import ElementClicked from '../element-clicked';
 
 export default class ClickEventHandler {
-  constructor(options) {
-    this._events = fromEvent(document, 'click')
+  constructor(sources, options) {
+    this._events = fromEvent(sources, 'click')
       .pipe(
         throttleTime(200),
         map((event) => new ElementClicked(event, options))

--- a/src/recorder/events/handlers/drag-event-handler.js
+++ b/src/recorder/events/handlers/drag-event-handler.js
@@ -4,10 +4,10 @@ import {map} from 'rxjs/operators';
 import ElementDragged from '../element-dragged';
 
 export default class DragEventHandler {
-  constructor(options) {
+  constructor(sources, options) {
     this._events = zip(
-      fromEvent(document, 'dragstart'),
-      fromEvent(document, 'drop')
+      fromEvent(sources, 'dragstart'),
+      fromEvent(sources, 'drop')
     )
       .pipe(map(([from, to]) => {
         return new ElementDragged(from, to, options);

--- a/src/recorder/events/handlers/enter-event-handler.js
+++ b/src/recorder/events/handlers/enter-event-handler.js
@@ -5,8 +5,8 @@ import EnterKeyPressed from '../enter-key-pressed';
 const ENTER_KEY_CODE = 13;
 
 export default class EnterKeyPressEventHandler {
-  constructor(options) {
-    this._events = fromEvent(document, 'keypress')
+  constructor(sources, options) {
+    this._events = fromEvent(sources, 'keypress')
       .pipe(
         filter((event) => event.key === ENTER_KEY_CODE || event.which === ENTER_KEY_CODE),
         throttleTime(500),

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -4,9 +4,9 @@ import {map} from 'rxjs/operators';
 import ValueEntered from '../value-entered';
 
 export default class InputEventHandler {
-  constructor(options) {
+  constructor(sources, options) {
     this.saveAllData = options.saveAllData;
-    this._events = fromEvent(document, 'change')
+    this._events = fromEvent(sources, 'change')
       .pipe(
         map((event) => new ValueEntered(event, this.saveAllData, options))
       );

--- a/src/recorder/events/handlers/navigate-event-handler.js
+++ b/src/recorder/events/handlers/navigate-event-handler.js
@@ -3,8 +3,8 @@ import {map} from 'rxjs/operators';
 import BrowserHistoryChange from '../browser-history-change';
 
 export default class NavigateEventHandler {
-  constructor() {
-    this._events = fromEvent(window, 'popstate')
+  constructor(sources) {
+    this._events = fromEvent(sources, 'popstate')
       .pipe(
         map((event) => {
           return new BrowserHistoryChange(event);

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -13,8 +13,10 @@ export default class Recorder {
   }
 
   startRecorder(config) {
-    this.eventListener = new EventListener(config);
-    if (Recorder.shouldDispatchEvents(config)) {
+    let dispatchEvents = Recorder.shouldDispatchEvents(config);
+
+    this.eventListener = new EventListener(config, dispatchEvents);
+    if (dispatchEvents) {
       // eslint-disable-next-line no-undef,max-len
       this.url = `${RECORDER_URL}/v1/events/${Session.getSession() || ''}`;
       this.eventListener


### PR DESCRIPTION
Listen to events on the document object of all static iframes. 
This only works for iframes from the same origin as the parent window. iframes from different origins are ignored because we can't access them.