### PR TITLE
Remove split from innerText identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -139,7 +139,7 @@ export default class Event {
     }
     if (!this.isHtmlOrBody(srcElement) && this.considerInnerText(srcElement) &&
       srcElement.innerText && srcElement.innerText.trim()) {
-      return srcElement.innerText.trim().split('\n')[0];
+      return srcElement.innerText.trim();
     }
     if (srcElement.ariaLabel) {
       return srcElement.ariaLabel;

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -18,7 +18,17 @@ function possiblyRelated(element, label) {
   return doSidesIntersect(elementRect, labelRect);
 }
 
+function isInput(element) {
+  return element.tagName && (element.tagName.toLowerCase() === 'input' ||
+    element.tagName.toLowerCase() === 'select' ||
+    element.tagName.toLowerCase() === 'textarea');
+}
+
 function getRelatedLabel(element) {
+  if (!isInput(element) || !element.id) {
+    return '';
+  }
+
   let labelElement = document.querySelector(`label[for="${element.id}"]`);
 
   return labelElement ? labelElement.innerText : '';
@@ -26,9 +36,7 @@ function getRelatedLabel(element) {
 
 function getLabelForElement(element) {
   try {
-    if (element.tagName && (element.tagName.toLowerCase() !== 'input' &&
-                            element.tagName.toLowerCase() !== 'select' &&
-                            element.tagName.toLowerCase() !== 'textarea')) {
+    if (!isInput(element)) {
       return '';
     }
 


### PR DESCRIPTION
Also stopped looking for direct labels (with for attr) for elements that are not inputs or elements that don't have an id