### PR TITLE
Improve button identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -15,3 +15,13 @@ module.exports.INLINE_TAGS = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym',
   'button', 'input', 'label', 'select', 'textarea'];
 
 module.exports.CONSIDER_INNER_TEXT_TAGS = ['li', 'mat-slide-toggle'];
+
+module.exports.isInput = function (element) {
+  return element.tagName && (element.tagName.toLowerCase() === 'input' ||
+    element.tagName.toLowerCase() === 'select' ||
+    element.tagName.toLowerCase() === 'textarea');
+};
+
+module.exports.isButtonOrLink = function (element) {
+  return (element.tagName && (element.tagName.toLowerCase() === 'button' || element.tagName.toLowerCase() === 'a'));
+};


### PR DESCRIPTION
For click events: If the clicked element is not an input, stop looking at ancestors for identifiers when encountering a button or a link. In other words, if the clicked element is inside a button or link, only pick the identifier from an element that is inside that button or link.

Also deal with multiline innerText descriptors by replacing breaks with spaces