### PR TITLE
Get text for non-inline elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -4,7 +4,7 @@ import { isVisible } from '../helpers/rect-helper';
 
 export default class Event {
   constructor(event, options) {
-    const element = event['srcElement'];
+    const element = event['toElement'] ? event['toElement'] : event['srcElement'];
 
     if (!element) {
       return;
@@ -139,17 +139,11 @@ export default class Event {
     if (srcElement.name) {
       return srcElement.name;
     }
-    if (!this.isHtmlOrBody(srcElement) && this.considerInnerText(srcElement) &&
-      srcElement.innerText && srcElement.innerText.trim()) {
-      let textIdentifier = srcElement.innerText
-        .replace('\r\n', '\n')
-        .split('\n')
-        .map(part => part.trim())
-        .filter(part => part).join(' ');
 
-      if (textIdentifier) {
-        return textIdentifier;
-      }
+    let text = this.getText(srcElement);
+
+    if (text) {
+      return text;
     }
     if (srcElement.ariaLabel) {
       return srcElement.ariaLabel;
@@ -173,6 +167,28 @@ export default class Event {
     }
     if (useClass && srcElement.className && typeof srcElement.className === 'string') {
       return srcElement.className;
+    }
+    return '';
+  }
+
+  getText(srcElement) {
+    if (this.isHtmlOrBody(srcElement)) {
+      return '';
+    }
+    let text = '';
+
+    if (this.considerInnerText(srcElement)) {
+      text = srcElement.innerText;
+    } else {
+      text = [].reduce.call(srcElement.childNodes,
+        (a, b) => a + (b.nodeType === 3 ? ' ' + b.textContent.trim() : ''),
+        '');
+    }
+    if (text) {
+      return text.replace('\r\n', '\n')
+        .split('\n')
+        .map(part => part.trim())
+        .filter(part => part).join(' ');
     }
     return '';
   }

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -14,7 +14,7 @@ module.exports.INLINE_TAGS = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym',
   'strong', 'samp', 'time', 'var', 'a', 'bdo', 'br', 'img', 'svg', 'map', 'object', 'q', 'script', 'span', 'sub', 'sup',
   'button', 'input', 'label', 'select', 'textarea'];
 
-module.exports.CONSIDER_INNER_TEXT_TAGS = ['li', 'mat-slide-toggle'];
+module.exports.CONSIDER_INNER_TEXT_TAGS = ['mat-slide-toggle'];
 
 module.exports.isInput = function (element) {
   return element.tagName && (element.tagName.toLowerCase() === 'input' ||


### PR DESCRIPTION
Reworked text descriptor to look for contained text for non-inline tags.

Also use the event's `toElement` if present to get the actual element clicked.