### PR TITLE
Record hover events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/element-hovered.js
+++ b/src/recorder/events/element-hovered.js
@@ -1,0 +1,9 @@
+import eventTypes from './event-types';
+import Event from './event';
+
+export default class ElementHovered extends Event {
+  constructor(event, options) {
+    super(event, options);
+    this.type = eventTypes.HOVER;
+  }
+};

--- a/src/recorder/events/event-listener.js
+++ b/src/recorder/events/event-listener.js
@@ -2,7 +2,7 @@ import {from} from 'rxjs';
 import { publish, mergeAll} from 'rxjs/operators';
 
 import {ClickEventHandler, InputEventHandler, DragEventHandler,
-  NavigateEventHandler, EnterKeyPressEventHandler} from './handlers';
+  NavigateEventHandler, EnterKeyPressEventHandler, HoverEventHandler} from './handlers';
 
 export default class EventListener {
   constructor(options, dispatchEvents) {
@@ -19,18 +19,17 @@ export default class EventListener {
         }
       }
     }
-    this._clickEventHandler = new ClickEventHandler(documents, options);
-    this._inputEventHandler = new InputEventHandler(documents, options);
-    this._dragEventHandler = new DragEventHandler(documents, options);
-    this._navigateEventHandler = new NavigateEventHandler(windows);
-    this._enterKeyPressEventHandler = new EnterKeyPressEventHandler(documents, options);
-    this._events = from([
-      this._clickEventHandler.events,
-      this._inputEventHandler.events,
-      this._dragEventHandler.events,
-      this._navigateEventHandler.events,
-      this._enterKeyPressEventHandler.events
-    ])
+    let eventSources = [(new ClickEventHandler(documents, options)).events,
+      (new InputEventHandler(documents, options)).events,
+      (new DragEventHandler(documents, options)).events,
+      (new NavigateEventHandler(windows)).events,
+      (new EnterKeyPressEventHandler(documents, options)).events];
+
+    if (!dispatchEvents) {
+      eventSources.push((new HoverEventHandler(documents, options)).events);
+    }
+
+    this._events = from(eventSources)
       .pipe(mergeAll(), publish());
     this._events.connect();
   }

--- a/src/recorder/events/event-types.js
+++ b/src/recorder/events/event-types.js
@@ -3,7 +3,8 @@ const eventTypes = {
   DRAG_AND_DROP: 'dragAndDrop',
   INPUT: 'input',
   BROWSER_HISTORY_CHANGE: 'browserHistoryChange',
-  ENTER_KEY_PRESS: 'enterKeyPress'
+  ENTER_KEY_PRESS: 'enterKeyPress',
+  HOVER: 'hover'
 };
 
 export default eventTypes;

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -5,7 +5,7 @@ import { isVisible } from '../helpers/rect-helper';
 
 export default class Event {
   constructor(event, options) {
-    let element = event['toElement'] ? event['toElement'] : event['srcElement'];
+    let element = event.target || event.toElement || event.srcElement;
 
     element = this.skipSVGInternals(element);
 

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -1,0 +1,34 @@
+import {zip, fromEvent} from 'rxjs';
+import {map, filter} from 'rxjs/operators';
+import ElementHovered from '../element-hovered';
+
+function isHoverable(element) {
+  while (element) {
+    if (element.tagName && element.tagName.toLowerCase().includes('nav') ||
+      element.className && typeof element.className === 'string' && element.className.toLowerCase().includes('hover')) {
+      return true;
+    }
+    element = element.parentNode;
+  }
+  return false;
+}
+
+export default class HoverEventHandler {
+  constructor(sources, options) {
+    this._events = zip(
+      fromEvent(sources, 'mouseover'),
+      fromEvent(sources, 'mouseout'),
+    ).pipe(
+      filter(([enter, leave]) => {
+        return enter.target === leave.target &&
+        leave.timeStamp - enter.timeStamp > 200 &&
+          isHoverable(enter.target);
+      }),
+      map(([, leave]) => new ElementHovered(leave, options))
+    );
+  }
+
+  get events() {
+    return this._events;
+  }
+};

--- a/src/recorder/events/handlers/index.js
+++ b/src/recorder/events/handlers/index.js
@@ -3,5 +3,7 @@ import InputEventHandler from './input-event-handler';
 import DragEventHandler from './drag-event-handler';
 import NavigateEventHandler from './navigate-event-handler';
 import EnterKeyPressEventHandler from './enter-event-handler';
+import HoverEventHandler from './hover-event-handler';
 
-export {ClickEventHandler, InputEventHandler, DragEventHandler, NavigateEventHandler, EnterKeyPressEventHandler};
+export {ClickEventHandler, InputEventHandler, DragEventHandler,
+  NavigateEventHandler, EnterKeyPressEventHandler, HoverEventHandler};


### PR DESCRIPTION
Only catch hover events from relevant elements.
Also prioritized the event's target over `toElement` and `srcElement` since they are [out of spec](https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement)