### PR TITLE
Add a small delay between events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -14,7 +14,7 @@ module.exports.INLINE_TAGS = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym',
   'strong', 'samp', 'time', 'var', 'a', 'bdo', 'br', 'img', 'svg', 'map', 'object', 'q', 'script', 'span', 'sub', 'sup',
   'button', 'input', 'label', 'select', 'textarea'];
 
-module.exports.CONSIDER_INNER_TEXT_TAGS = ['mat-slide-toggle'];
+module.exports.CONSIDER_INNER_TEXT_TAGS = ['mat-slide-toggle', 'md-card', 'md-card-content'];
 
 module.exports.isInput = function (element) {
   return element.tagName && (element.tagName.toLowerCase() === 'input' ||

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -1,5 +1,7 @@
 import { EventListener } from './events';
 import { ajax } from 'rxjs/ajax';
+import { zip, interval } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 const DEFAULT_PRIORITY = -100;
 const Session = window['Session'] || {getSession: function () {}};
@@ -19,8 +21,8 @@ export default class Recorder {
     if (dispatchEvents) {
       // eslint-disable-next-line no-undef,max-len
       this.url = `${RECORDER_URL}/v1/events/${Session.getSession() || ''}`;
-      this.eventListener
-        .events()
+      zip(this.eventListener.events(), interval(50))
+        .pipe(map(([evt]) => evt))
         .subscribe((event) => {
           this.postNewEvent(event);
         });


### PR DESCRIPTION
This prevents concurrency issues on the recorder plugin.

Also consider text for md-card and  md-card-content tags