### PR TITLE
Event improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -1,12 +1,15 @@
-import {fromEvent} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {fromEvent, merge} from 'rxjs';
+import {map, filter} from 'rxjs/operators';
 
 import ValueEntered from '../value-entered';
 
 export default class InputEventHandler {
   constructor(sources, options) {
     this.saveAllData = options.saveAllData;
-    this._events = fromEvent(sources, 'change')
+    this._events = merge(
+      fromEvent(sources, 'change'),
+      fromEvent(sources, 'input').pipe(filter((evt) => evt.target.isContentEditable))
+    )
       .pipe(
         map((event) => new ValueEntered(event, this.saveAllData, options))
       );

--- a/src/recorder/events/value-entered.js
+++ b/src/recorder/events/value-entered.js
@@ -4,7 +4,7 @@ import Event from './event';
 export default class ValueEntered extends Event {
   constructor(event, saveAllData, options) {
     super(event, options);
-    const element = event['srcElement'];
+    const element = event.target;
 
     if (!element) {
       return;
@@ -23,7 +23,7 @@ export default class ValueEntered extends Event {
     }
 
     if (saveAllData === 'true' || saveAllData === true) {
-      this.value = element.value;
+      this.value = element.value || element.innerText;
     }
     this.type = eventTypes.INPUT;
   }


### PR DESCRIPTION
Added support for content-editable edits using input events. 

Improved algorithm for getting button identifiers (don't stop at first non-pointer cursor element if the clicked element has non-pointer cursor)

Don't process label, identifier, context, etc for popstate events. Not only this wastes resources, it causes errors in some cases because the popstate target is the window object, with doesn't contain some properties we look for in elements.