### PR TITLE
Unsubscribe from current subscription when restarting the recorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -45,7 +45,7 @@ export default class Recorder {
   }
 
   subscribeToEventsPlugin() {
-    this.eventListener
+    this.eventSubscription = this.eventListener
       .events()
       .subscribe((event) => {
         // Left for backward compability. Init
@@ -93,6 +93,7 @@ export default class Recorder {
   }
 
   restartWithConfig(config) {
+    this.eventSubscription.unsubscribe();
     this.config = config;
     this.startRecorder(config);
   }


### PR DESCRIPTION
Successive restarts where causing each event to be handled additional times.