### PR TITLE
Fix undefined access of eventSubscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -93,7 +93,9 @@ export default class Recorder {
   }
 
   restartWithConfig(config) {
-    this.eventSubscription.unsubscribe();
+    if (this.eventSubscription && this.eventSubscription.unsubscribe) {
+      this.eventSubscription.unsubscribe();
+    }
     this.config = config;
     this.startRecorder(config);
   }


### PR DESCRIPTION
`eventSubscription` is populated when a plugin recording starts.
If the plugin is used to record on pages where the library is already deployed, `restartWithConfig` gets called before `eventSubscription` is initialized