### PR TITLE
Ignore the element's label when looking at context-index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.24",
+  "version": "0.0.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -1,6 +1,6 @@
 import { getRelatedLabel, getLabelForElement } from '../helpers/label-finder';
 import { HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
-  isInput, isButtonOrLink, isInputButton } from '../helpers/html-tags';
+  isInput, isButtonOrLink, isButton } from '../helpers/html-tags';
 import { isVisible } from '../helpers/rect-helper';
 
 export default class Event {
@@ -44,7 +44,12 @@ export default class Event {
     this.url = location.href;
 
     if (event.type !== 'popstate') {
-      this.label = getLabelForElement(element);
+      element.labelElement = getLabelForElement(element);
+
+      if (element.labelElement) {
+        this.label = element.labelElement.innerText;
+      }
+
       if (this.shouldCheckForCustomTag()) {
         this.customTag = this.getNearestCustomTag(element);
       }
@@ -134,14 +139,14 @@ export default class Event {
     if (!srcElement) {
       return '';
     }
-    if (isInputButton(srcElement) && srcElement.value) {
+    if (isButton(srcElement) && srcElement.value) {
       return srcElement.value;
     }
 
     let relatedLabel = getRelatedLabel(srcElement);
 
     if (relatedLabel) {
-      return relatedLabel;
+      return relatedLabel.innerText;
     }
     if (srcElement.placeholder) {
       return srcElement.placeholder;
@@ -167,10 +172,10 @@ export default class Event {
     if (srcElement.resourceId || srcElement.id) {
       return srcElement.resourceId || srcElement.id;
     }
-    let label = getLabelForElement(srcElement);
+    let labelElement = getLabelForElement(srcElement);
 
-    if (label) {
-      return label;
+    if (labelElement) {
+      return labelElement.innerText;
     }
     if (useClass && srcElement.className && typeof srcElement.className === 'string') {
       return srcElement.className;
@@ -205,6 +210,7 @@ export default class Event {
       if (isVisible(similarNode) &&
         this.getDescriptor(similarNode, true) === elementDescriptor &&
         !this.isContainedByOrContains(srcElement, similarNode) &&
+        similarNode !== srcElement.labelElement &&
         !similarNodeArray.find(current => this.isContainedByOrContains(current.node, similarNode))) {
         similarNodeArray.push({
           node: similarNode,

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -26,7 +26,10 @@ module.exports.isButtonOrLink = function (element) {
   return (element.tagName && (element.tagName.toLowerCase() === 'button' || element.tagName.toLowerCase() === 'a'));
 };
 
-module.exports.isInputButton = function (element) {
+module.exports.isButton = function (element) {
+  if (element.tagName && element.tagName.toLowerCase() === 'button') {
+    return true;
+  }
   return (element.tagName && element.tagName.toLowerCase() === 'input') &&
     (element.type && (element.type === 'submit' || element.type === 'button' || element.type === 'reset'));
 };

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -29,15 +29,13 @@ function getRelatedLabel(element) {
     return '';
   }
 
-  let labelElement = document.querySelector(`label[for="${element.id}"]`);
-
-  return labelElement ? labelElement.innerText : '';
+  return document.querySelector(`label[for="${element.id}"]`);
 }
 
 function getLabelForElement(element) {
   try {
     if (!isInput(element)) {
-      return '';
+      return null;
     }
 
     let relatedLabel = getRelatedLabel(element);
@@ -65,9 +63,9 @@ function getLabelForElement(element) {
         }
       }
     }
-    return labelElement != null ? labelElement.innerText : '';
+    return labelElement;
   } catch (error) {
-    return '';
+    return null;
   }
 }
 


### PR DESCRIPTION
When an element has a label, its identifier should be the same as the element's identifier. This can cause a context-index calculation where the label and the element are indexed separately where they should be grouped together.

Also changed isInputButton to also check for button tag.