### PR TITLE
Don't use innerText for inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -124,7 +124,7 @@ export default class Event {
     let identifier = this.getDescriptor(element, useClass),
       identifiedElement = element;
 
-    if (!identifier) {
+    if (!identifier && !isInput(element)) {
       identifiedElement = this.getIdentifiableParent(element, '', 10,
         useClass, isNotClickOfInput, this.hasPointerCursor(element));
       identifier = this.getDescriptor(identifiedElement, useClass);
@@ -154,7 +154,7 @@ export default class Event {
     if (srcElement.name) {
       return srcElement.name;
     }
-    if (srcElement.innerText) {
+    if (!isInput(srcElement) && srcElement.innerText) {
       return srcElement.innerText;
     }
     if (srcElement.ariaLabel) {

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -19,7 +19,8 @@ module.exports.CONSIDER_INNER_TEXT_TAGS = ['mat-slide-toggle'];
 module.exports.isInput = function (element) {
   return element.tagName && (element.tagName.toLowerCase() === 'input' ||
     element.tagName.toLowerCase() === 'select' ||
-    element.tagName.toLowerCase() === 'textarea');
+    element.tagName.toLowerCase() === 'textarea' ||
+    element.isContentEditable);
 };
 
 module.exports.isButtonOrLink = function (element) {


### PR DESCRIPTION
Don't look into parents for identifiers for inputs either. Also consider contentEditable elements as inputs for these checks