### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.32",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3106,9 +3106,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -5436,9 +5436,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "loglevel": {
@@ -6985,9 +6985,9 @@
       }
     },
     "session-management-js": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/session-management-js/-/session-management-js-0.0.6.tgz",
-      "integrity": "sha512-sx0d83iV4wv3qHEn5BFUzv1J+lZwIu2rU7PaiVoHfmWMY0jM0RK34wFwSIhFxxqUpQ2SSfZwZFpagM4CZLlbfg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/session-management-js/-/session-management-js-0.0.7.tgz",
+      "integrity": "sha512-pCzKYH+ZrFW1XNL8tsXt3zsFz5SfuZ7s/d/HQeTbnJf6qrId/8ZmPtG3DYT+6OrpYJs4VycDBOwENmBw/rUsxg==",
       "requires": {
         "psl": "^1.8.0"
       }
@@ -8384,9 +8384,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "",
   "private": true,
   "scripts": {
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "rxjs": "6.5.2",
-    "session-management-js": "^0.0.6"
+    "session-management-js": "^0.0.7"
   }
 }


### PR DESCRIPTION
Bump

- session-management 0.0.6 to 0.0.7
- elliptic 6.5.2 to 6.5.3
- lodash 4.15.17 to 4.15.19
- websocket-extensions 0.1.3 to 0.1.4