### PR TITLE
Don't use innerText for contextOf descriptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
ContextOf elements are usually containers, using innerText for them is likely to produce bad steps.