### PR TITLE
Reworked label search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -1,4 +1,4 @@
-import { getRelatedLabel, getLabelForElement } from '../helpers/label-finder';
+import { getLabelForElement } from '../helpers/label-finder';
 import { HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
   isInput, isButtonOrLink, isButton } from '../helpers/html-tags';
 import { isVisible } from '../helpers/rect-helper';
@@ -44,7 +44,7 @@ export default class Event {
     this.url = location.href;
 
     if (event.type !== 'popstate') {
-      element.labelElement = getLabelForElement(element);
+      element.labelElement = getLabelForElement(element).label;
 
       if (element.labelElement) {
         this.label = element.labelElement.innerText;
@@ -143,10 +143,10 @@ export default class Event {
       return srcElement.value;
     }
 
-    let relatedLabel = getRelatedLabel(srcElement);
+    let relatedLabel = getLabelForElement(srcElement);
 
-    if (relatedLabel) {
-      return relatedLabel.innerText;
+    if (relatedLabel.highConfidence) {
+      return relatedLabel.label.innerText;
     }
     if (srcElement.placeholder) {
       return srcElement.placeholder;
@@ -172,10 +172,9 @@ export default class Event {
     if (srcElement.resourceId || srcElement.id) {
       return srcElement.resourceId || srcElement.id;
     }
-    let labelElement = getLabelForElement(srcElement);
 
-    if (labelElement) {
-      return labelElement.innerText;
+    if (relatedLabel.label) {
+      return relatedLabel.label.innerText;
     }
     if (useClass && srcElement.className && typeof srcElement.className === 'string') {
       return srcElement.className;

--- a/src/recorder/helpers/rect-helper.js
+++ b/src/recorder/helpers/rect-helper.js
@@ -9,20 +9,11 @@ function contains(rect, otherRect) {
     valueInRange(otherRect.y + otherRect.height, rect.y, rect.y + rect.height);
 }
 
-function doSidesIntersect(rect, otherRect) {
-  const horizontalIntersection = (rect.x + rect.width >= otherRect.x) ||
-    (otherRect.x + otherRect.width >= rect.x);
-  const verticalIntersection = rect.y + rect.height >= otherRect.y ||
-    (otherRect.y + otherRect.height >= rect.y);
-
-  return horizontalIntersection || verticalIntersection;
-}
-
 function distanceBetweenLeftCenterPoints(element, otherElement) {
   const rect = element.getBoundingClientRect();
   const otherRect = otherElement.getBoundingClientRect();
-  const rectMidY = rect.bottom + rect.height / 2;
-  const otherRectMidY = otherRect.bottom + otherRect.height / 2;
+  const rectMidY = rect.bottom - rect.height / 2;
+  const otherRectMidY = otherRect.bottom - otherRect.height / 2;
   const distanceSquared = Math.pow(rect.x - otherRect.x, 2) + Math.pow(rectMidY - otherRectMidY, 2);
 
   return Math.sqrt(distanceSquared);
@@ -126,4 +117,4 @@ function isVisible(node) {
   return isAccessible && style.getPropertyValue('display') !== 'none';
 }
 
-export {contains, doSidesIntersect, distanceBetweenLeftCenterPoints, isVisible};
+export {contains, distanceBetweenLeftCenterPoints, isVisible};


### PR DESCRIPTION
- Fixed left-center point in `distanceBetweenLeftCenterPoints`: y increases from top to bottom, that means the vertical center of a rect is `bottom - height/2`

- Don't consider empty labels

- Restricted which labels to consider when searching: `possiblyRelated` only consider2 labels whose top left corner are above and to the left of the element. see screenshot of search area for "Last Name" input
![search area](https://user-images.githubusercontent.com/54808102/89716446-77148c80-d983-11ea-9969-fd5593612184.png)

- If the element's parent has a `input-group` class use the parent as element: because inputs in an input group often have an `input-addon` element to their left which messes up calculations

- Added a `highConfidence` flag, labels with high confidence are prioritized over other identifiers: the found label is high confidence if:

1. its `for` attribute matches the input's `id`
2. its on top of the element (the label's bottom is higher than the middle of the element) and the distance between its leftmost center point and the element's is less or equal than 75px
3. its to the left of the element (the label's rightmost point is lower than a quarter of the element) and the distance between its leftmost center point and the element's is less or equal than 150px

see screenshot: if the label's bottom is on the green area it is considered "on top", if its on the red area its considered "to the left"
![areas of confidence](https://user-images.githubusercontent.com/54808102/89716718-c1970880-d985-11ea-93a3-a063699a3dbe.png)
