### PR TITLE
Use capture instead of bubbling on event listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/handlers/click-event-handler.js
+++ b/src/recorder/events/handlers/click-event-handler.js
@@ -4,7 +4,7 @@ import ElementClicked from '../element-clicked';
 
 export default class ClickEventHandler {
   constructor(sources, options) {
-    this._events = fromEvent(sources, 'click')
+    this._events = fromEvent(sources, 'click', { capture: true })
       .pipe(
         throttleTime(200),
         map((event) => new ElementClicked(event, options))

--- a/src/recorder/events/handlers/drag-event-handler.js
+++ b/src/recorder/events/handlers/drag-event-handler.js
@@ -6,8 +6,8 @@ import ElementDragged from '../element-dragged';
 export default class DragEventHandler {
   constructor(sources, options) {
     this._events = zip(
-      fromEvent(sources, 'dragstart'),
-      fromEvent(sources, 'drop')
+      fromEvent(sources, 'dragstart', { capture: true }),
+      fromEvent(sources, 'drop', { capture: true })
     )
       .pipe(map(([from, to]) => {
         return new ElementDragged(from, to, options);

--- a/src/recorder/events/handlers/enter-event-handler.js
+++ b/src/recorder/events/handlers/enter-event-handler.js
@@ -6,7 +6,7 @@ const ENTER_KEY_CODE = 13;
 
 export default class EnterKeyPressEventHandler {
   constructor(sources, options) {
-    this._events = fromEvent(sources, 'keypress')
+    this._events = fromEvent(sources, 'keypress', { capture: true })
       .pipe(
         filter((event) => event.key === ENTER_KEY_CODE || event.which === ENTER_KEY_CODE),
         throttleTime(500),

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -16,8 +16,8 @@ function isHoverable(element) {
 export default class HoverEventHandler {
   constructor(sources, options) {
     this._events = zip(
-      fromEvent(sources, 'mouseover'),
-      fromEvent(sources, 'mouseout'),
+      fromEvent(sources, 'mouseover', { capture: true }),
+      fromEvent(sources, 'mouseout', { capture: true }),
     ).pipe(
       filter(([enter, leave]) => {
         return enter.target === leave.target &&

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -7,8 +7,8 @@ export default class InputEventHandler {
   constructor(sources, options) {
     this.saveAllData = options.saveAllData;
     this._events = merge(
-      fromEvent(sources, 'change'),
-      fromEvent(sources, 'input').pipe(filter((evt) => evt.target.isContentEditable))
+      fromEvent(sources, 'change', { capture: true }),
+      fromEvent(sources, 'input', { capture: true }).pipe(filter((evt) => evt.target.isContentEditable))
     )
       .pipe(
         map((event) => new ValueEntered(event, this.saveAllData, options))


### PR DESCRIPTION
Since event listeners use bubbling by default, and we attach ours to the document, they are the last ones to process the events. If any listener in the hierarchy stops propagation we don't get to process the event.

The way around this is to listen to the events on the capture phase, which runs listeners from top to bottom of the hierarchy and runs before the bubbling phase. This means that if we use capture listeners on the document element, we get to process the event first, which is exactly what we want.

some info here: https://javascript.info/bubbling-and-capturing#capturing