### PR TITLE
Support divs as labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -23,6 +23,10 @@ module.exports.isInput = function (element) {
     element.isContentEditable);
 };
 
+module.exports.isSwitch = function (element) {
+  return element.type && ((element.type.toLowerCase() === 'checkbox') || (element.type.toLowerCase() === 'radio'));
+};
+
 module.exports.isButtonOrLink = function (element) {
   return (element.tagName && (element.tagName.toLowerCase() === 'button' || element.tagName.toLowerCase() === 'a'));
 };

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -1,23 +1,18 @@
 import { contains, distanceBetweenLeftCenterPoints, isVisible } from './rect-helper';
+import { isInput, isSwitch } from './html-tags';
 
 const labelTags = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd', 'bdo', 'map',
-  'q', 'span', 'sub', 'sup', 'label', 'text'];
+  'q', 'span', 'sub', 'sup', 'label', 'div', 'text'];
 
 function possiblyRelated(element, label) {
   const elementRect = element.getBoundingClientRect();
   const labelRect = label.getBoundingClientRect();
 
   if (contains(elementRect, labelRect) || contains(labelRect, elementRect)) {
-    return true;
+    return isSwitch(element);
   }
 
   return labelRect.left <= (elementRect.left + (elementRect.width * 0.1)) && labelRect.top <= elementRect.bottom;
-}
-
-function isInput(element) {
-  return element.tagName && (element.tagName.toLowerCase() === 'input' ||
-    element.tagName.toLowerCase() === 'select' ||
-    element.tagName.toLowerCase() === 'textarea');
 }
 
 function getRelatedLabel(element) {
@@ -34,6 +29,10 @@ function isLabelWithHighConfidence(element, labelElement, distance) {
 
     let elementRect = element.getBoundingClientRect();
 
+    // label contains switch
+    if (contains(labelRect, elementRect) && isSwitch(element) && distance <= 50) {
+      return true;
+    }
     // label on top of the element
     if ((labelRect.bottom <= (elementRect.bottom - (elementRect.height / 2))) && distance <= 75) {
       return true;


### PR DESCRIPTION
Consider div elements when looking for labels.
I also added a small fix that was preventing label-lookup for content-editable divs