### PR TITLE
Shorten the hover window to 100ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -21,7 +21,7 @@ export default class HoverEventHandler {
     ).pipe(
       filter(([enter, leave]) => {
         return enter.target === leave.target &&
-        leave.timeStamp - enter.timeStamp > 200 &&
+        (leave.timeStamp - enter.timeStamp) > 100 &&
           isHoverable(enter.target);
       }),
       map(([, leave]) => new ElementHovered(leave, options))


### PR DESCRIPTION
Lower the minimum duration required to record a hover from 200ms to 100ms (time between mouse entering and leaving the element)