### PR TITLE
Added anchor element reference to recorded events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -16,6 +16,11 @@ module.exports.INLINE_TAGS = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym',
 
 module.exports.CONSIDER_INNER_TEXT_TAGS = ['mat-slide-toggle'];
 
+const LABEL_TAGS = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd',
+  'bdo', 'map', 'q', 'span', 'sub', 'sup', 'label', 'text'];
+
+module.exports.LABEL_TAGS = LABEL_TAGS;
+
 module.exports.isInput = function (element) {
   return element.tagName && (element.tagName.toLowerCase() === 'input' ||
     element.tagName.toLowerCase() === 'select' ||
@@ -37,6 +42,14 @@ module.exports.isButton = function (element) {
   }
   return (element.tagName && element.tagName.toLowerCase() === 'input') &&
     (element.type && (element.type === 'submit' || element.type === 'button' || element.type === 'reset'));
+};
+
+module.exports.isLabel = function (element) {
+  if (!element.tagName) {
+    return false;
+  }
+  return LABEL_TAGS.indexOf(element.tagName.toLowerCase()) !== -1 ||
+    (element.tagName.toLowerCase() === 'div' && !!element.innerText);
 };
 
 module.exports.LOG_OUT_IDENTIFIERS = ['logout', 'log out', 'signout', 'sign out', 'log me out', 'sign me out'];

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -1,8 +1,5 @@
 import { contains, distanceBetweenLeftCenterPoints, isVisible } from './rect-helper';
-import { isInput, isSwitch } from './html-tags';
-
-const labelTags = ['b', 'big', 'i', 'small', 'tt', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd', 'bdo', 'map',
-  'q', 'span', 'sub', 'sup', 'label', 'div', 'text'];
+import { isInput, isSwitch, LABEL_TAGS } from './html-tags';
 
 function possiblyRelated(element, label) {
   const elementRect = element.getBoundingClientRect();
@@ -71,7 +68,7 @@ function getLabelForElement(element) {
     let shortestDistance = null;
 
     if (element.getBoundingClientRect) {
-      const labelElements = document.querySelectorAll(labelTags.join() + ',.label');
+      const labelElements = document.querySelectorAll(LABEL_TAGS.join() + ',.label');
 
       let possibleLabels = Array.from(labelElements)
         .filter(label => isVisible(label) && possiblyRelated(element, label) && label.innerText);

--- a/src/recorder/helpers/query-helper.js
+++ b/src/recorder/helpers/query-helper.js
@@ -11,12 +11,17 @@ function leafContainsLowercaseNormalizedMultiple(searchParams = []) {
   return searchParams.map((searchParam) => leafContainsLowercaseNormalized(searchParam)).join(' | ');
 }
 
-function attrMatch(attrValue) {
-  return QUERYABLE_ATTRS.map((attr) => `//*/body//*[@${attr}="${attrValue}"]`).join(' | ');
+function attrMatch(attrValue, searchRoot = '//*/body') {
+  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[@${attr}="${attrValue}"]`).join(' | ');
+}
+
+function attrNonMatch(attrValue, searchRoot = '//*/body') {
+  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[not(@${attr}="${attrValue}")]`).join(' | ');
 }
 
 function attrMatchMultiple(attrValues = []) {
   return attrValues.map((value) => attrMatch(value)).join(' | ');
 }
 
-export { leafContainsLowercaseNormalized, leafContainsLowercaseNormalizedMultiple, attrMatch, attrMatchMultiple };
+export { leafContainsLowercaseNormalized, leafContainsLowercaseNormalizedMultiple,
+  attrMatch, attrMatchMultiple, attrNonMatch };


### PR DESCRIPTION
Look for the closest label-type element with a different identifier to use as anchor, and calculate its relation to the element (above, below, etc.)

Changed the "getContext" algorithm to only run if the element's identifier is not unique, and to prioritize anchor over context-index, we won't look for context-index if we find and anchor element