### PR TITLE
Added cleanup identifier quotes on xpath queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -5,7 +5,7 @@ import { HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
 import { isVisible, visualDistance, getRelation } from '../helpers/rect-helper';
 import {
   leafContainsLowercaseNormalizedMultiple, attrMatch,
-  attrMatchMultiple, attrNonMatch
+  attrMatchMultiple, attrNonMatch, cleanupQuotes
 } from '../helpers/query-helper';
 
 export default class Event {
@@ -255,7 +255,7 @@ export default class Event {
   }
 
   elementQuery(descriptor) {
-    return `//*[contains(normalize-space(), "${descriptor}")] | ` + attrMatch(descriptor);
+    return `//*[contains(normalize-space(), ${cleanupQuotes(descriptor)})] | ` + attrMatch(descriptor);
   }
 
   getIdentifiableParent(srcElement, childIdentifier, maxDepth, useClass, stopAtButton, stopAtLastPointer,
@@ -349,7 +349,7 @@ export default class Event {
   getAnchorElement(element, identifier) {
     // find elements with different identifiers
     let queryRoot = this.getXPathForElement(this.get10thAncestor(element)) || '/body',
-      query = `${queryRoot}//*[not(contains(normalize-space(), "${identifier}"))] | ` +
+      query = `${queryRoot}//*[not(contains(normalize-space(), ${cleanupQuotes(identifier)}))] | ` +
         attrNonMatch(identifier, queryRoot),
       differentIdNodes = document.evaluate(query, document, null, XPathResult.ANY_TYPE, null),
       currentDiffNode = differentIdNodes.iterateNext(),

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -4,8 +4,7 @@ import ElementHovered from '../element-hovered';
 
 function isHoverable(element) {
   while (element) {
-    if (element.tagName && element.tagName.toLowerCase().includes('nav') ||
-      element.className && typeof element.className === 'string' && element.className.toLowerCase().includes('hover')) {
+    if (element.tagName && element.tagName.toLowerCase().includes('nav')) {
       return true;
     }
     element = element.parentNode;

--- a/src/recorder/helpers/query-helper.js
+++ b/src/recorder/helpers/query-helper.js
@@ -2,9 +2,18 @@
 const QUERYABLE_ATTRS = ['text', 'hint', 'title', 'label', 'aria-label', 'name', 'id', 'data-test-id', 'class',
   'placeholder', 'alternative', 'source'];
 
+function cleanupQuotes(value) {
+  if (value.indexOf("'") === -1) {
+    return '\'' + value + '\'';
+  } else if (value.indexOf('\"') === -1) {
+    return '"' + value + '"';
+  }
+  return "concat('" + value.replace("'", "',\"'\",'") + "')";
+}
+
 function leafContainsLowercaseNormalized(searchParam) {
   return `//*/body//*[not(child::*) and contains(translate(normalize-space(.), "ABCDEFGHIJKLMNÑOPQRSTUVWXYZ",
-  "abcdefghijklmnñopqrstuvwxyz"), "${searchParam}")]`;
+  "abcdefghijklmnñopqrstuvwxyz"), ${cleanupQuotes(searchParam)})]`;
 }
 
 function leafContainsLowercaseNormalizedMultiple(searchParams = []) {
@@ -12,11 +21,11 @@ function leafContainsLowercaseNormalizedMultiple(searchParams = []) {
 }
 
 function attrMatch(attrValue, searchRoot = '//*/body') {
-  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[@${attr}="${attrValue}"]`).join(' | ');
+  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[@${attr}=${cleanupQuotes(attrValue)}]`).join(' | ');
 }
 
 function attrNonMatch(attrValue, searchRoot = '//*/body') {
-  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[not(@${attr}="${attrValue}")]`).join(' | ');
+  return QUERYABLE_ATTRS.map((attr) => `${searchRoot}//*[not(@${attr}=${cleanupQuotes(attrValue)})]`).join(' | ');
 }
 
 function attrMatchMultiple(attrValues = []) {
@@ -24,4 +33,4 @@ function attrMatchMultiple(attrValues = []) {
 }
 
 export { leafContainsLowercaseNormalized, leafContainsLowercaseNormalizedMultiple,
-  attrMatch, attrMatchMultiple, attrNonMatch };
+  attrMatch, attrMatchMultiple, attrNonMatch, cleanupQuotes };


### PR DESCRIPTION
Xpath queries don't support quote escaping so we have to deal with it by wrapping the identifier in single quotes if it has double quotes or viceversa.
If the identifier has both types of quotes we use replace and concat to assemble the proper string.

Also removed the class check from hover events that was picking up unnecessary events