### PR TITLE
Fix excessive reference elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -2,7 +2,7 @@ import { getLabelForElement } from '../helpers/label-finder';
 import { HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
   isInput, isButtonOrLink, isButton, LOG_OUT_IDENTIFIERS,
   LOG_IN_IDENTIFIERS, isLabel } from '../helpers/html-tags';
-import { isVisible, visualDistance, getRelation } from '../helpers/rect-helper';
+import {isVisible, visualDistance, getRelation, isPossiblyVisible} from '../helpers/rect-helper';
 import {
   leafContainsLowercaseNormalizedMultiple, attrMatch,
   attrMatchMultiple, attrNonMatch, cleanupQuotes
@@ -285,7 +285,8 @@ export default class Event {
       currentNode = similarNodes.iterateNext();
 
     while (currentNode) {
-      if (element !== currentNode && !this.isContainedByOrContains(element, currentNode) &&
+      if (element !== currentNode && element.labelElement !== currentNode &&
+        !this.isContainedByOrContains(element, currentNode) && isPossiblyVisible(currentNode) &&
         this.getIdentifier(currentNode, false, true, false).identifier === identifier) {
         return false;
       }

--- a/src/recorder/helpers/rect-helper.js
+++ b/src/recorder/helpers/rect-helper.js
@@ -227,6 +227,16 @@ function isNodeContainsOther(parent, child) {
   return false;
 }
 
+function isPossiblyVisible(node) {
+  let rect = getRect(node),
+    style = window.getComputedStyle(node);
+
+  return !!(node.offsetWidth || node.offsetHeight ||
+    (node.getClientRects() && node.getClientRects().length)) &&
+    style.getPropertyValue('visibility') !== 'hidden' &&
+    rect.height >= 1 && rect.width >= 1;
+}
+
 function isVisible(node) {
   let rect = getRect(node),
     windowRect = getWindowRect(),
@@ -234,12 +244,7 @@ function isVisible(node) {
     isOnScreen = hasRectIntersection(rect, windowRect),
     isAccessible = false;
 
-  let isPossiblyVisible = !!(node.offsetWidth || node.offsetHeight ||
-    (node.getClientRects() && node.getClientRects().length)) &&
-    style.getPropertyValue('visibility') !== 'hidden' &&
-    rect.height >= 1 && rect.width >= 1;
-
-  if (isOnScreen && isPossiblyVisible) {
+  if (isOnScreen && isPossiblyVisible(node)) {
     let center = getRectCenter(rect),
       relativeCenter = {
         x: center.x - windowRect.x,
@@ -258,4 +263,4 @@ function isVisible(node) {
   return isAccessible && style.getPropertyValue('display') !== 'none';
 }
 
-export {contains, distanceBetweenLeftCenterPoints, isVisible, visualDistance, getRelation};
+export {contains, distanceBetweenLeftCenterPoints, isPossiblyVisible, isVisible, visualDistance, getRelation};


### PR DESCRIPTION
We only look for reference elements (anchors) when the identifier for the event's target is non-unique. This check was failing when the "other element" was the element's label or when it wasn't visible at all.