### PR TITLE
Perfomance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/element-clicked.js
+++ b/src/recorder/events/element-clicked.js
@@ -3,8 +3,8 @@ import Event from './event';
 
 export default class ElementClicked extends Event {
 
-  constructor(event, options) {
-    super(event, options);
+  constructor(event) {
+    super(event);
 
     const element = event['srcElement'];
 

--- a/src/recorder/events/element-dragged.js
+++ b/src/recorder/events/element-dragged.js
@@ -2,8 +2,8 @@ import eventTypes from './event-types';
 import Event from './event';
 
 export default class ElementDragged extends Event {
-  constructor(from, to, options) {
-    super(from, options);
+  constructor(from, to) {
+    super(from);
     this.type = eventTypes.DRAG_AND_DROP;
     this.dragX = from.clientX;
     this.dragY = from.clientY;

--- a/src/recorder/events/element-hovered.js
+++ b/src/recorder/events/element-hovered.js
@@ -2,8 +2,8 @@ import eventTypes from './event-types';
 import Event from './event';
 
 export default class ElementHovered extends Event {
-  constructor(event, options) {
-    super(event, options);
+  constructor(event) {
+    super(event);
     this.type = eventTypes.HOVER;
   }
 };

--- a/src/recorder/events/enter-key-pressed.js
+++ b/src/recorder/events/enter-key-pressed.js
@@ -2,8 +2,8 @@ import eventTypes from './event-types';
 import Event from './event';
 
 export default class EnterKeyPressed extends Event {
-  constructor(event, options) {
-    super(event, options);
+  constructor(event) {
+    super(event);
     this.type = eventTypes.ENTER_KEY_PRESS;
   }
 };

--- a/src/recorder/events/event-listener.js
+++ b/src/recorder/events/event-listener.js
@@ -19,14 +19,14 @@ export default class EventListener {
         }
       }
     }
-    let eventSources = [(new ClickEventHandler(documents, options)).events,
+    let eventSources = [(new ClickEventHandler(documents)).events,
       (new InputEventHandler(documents, options)).events,
-      (new DragEventHandler(documents, options)).events,
+      (new DragEventHandler(documents)).events,
       (new NavigateEventHandler(windows)).events,
-      (new EnterKeyPressEventHandler(documents, options)).events];
+      (new EnterKeyPressEventHandler(documents)).events];
 
     if (!dispatchEvents) {
-      eventSources.push((new HoverEventHandler(documents, options)).events);
+      eventSources.push((new HoverEventHandler(documents)).events);
     }
 
     this._events = from(eventSources)

--- a/src/recorder/events/handlers/click-event-handler.js
+++ b/src/recorder/events/handlers/click-event-handler.js
@@ -3,11 +3,11 @@ import {map, throttleTime} from 'rxjs/operators';
 import ElementClicked from '../element-clicked';
 
 export default class ClickEventHandler {
-  constructor(sources, options) {
+  constructor(sources) {
     this._events = fromEvent(sources, 'click', { capture: true })
       .pipe(
         throttleTime(200),
-        map((event) => new ElementClicked(event, options))
+        map((event) => {return {event: event, processed: new ElementClicked(event)};})
       );
   }
 

--- a/src/recorder/events/handlers/drag-event-handler.js
+++ b/src/recorder/events/handlers/drag-event-handler.js
@@ -4,13 +4,13 @@ import {map} from 'rxjs/operators';
 import ElementDragged from '../element-dragged';
 
 export default class DragEventHandler {
-  constructor(sources, options) {
+  constructor(sources) {
     this._events = zip(
       fromEvent(sources, 'dragstart', { capture: true }),
       fromEvent(sources, 'drop', { capture: true })
     )
       .pipe(map(([from, to]) => {
-        return new ElementDragged(from, to, options);
+        return {event: to, processed: new ElementDragged(from, to)};
       }));
   }
 

--- a/src/recorder/events/handlers/enter-event-handler.js
+++ b/src/recorder/events/handlers/enter-event-handler.js
@@ -5,12 +5,12 @@ import EnterKeyPressed from '../enter-key-pressed';
 const ENTER_KEY_CODE = 13;
 
 export default class EnterKeyPressEventHandler {
-  constructor(sources, options) {
+  constructor(sources) {
     this._events = fromEvent(sources, 'keypress', { capture: true })
       .pipe(
         filter((event) => event.key === ENTER_KEY_CODE || event.which === ENTER_KEY_CODE),
         throttleTime(500),
-        map((event) => new EnterKeyPressed(event, options))
+        map((event) => {return {event: event, processed: new EnterKeyPressed(event)};})
       );
   }
 

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -13,7 +13,7 @@ function isHoverable(element) {
 }
 
 export default class HoverEventHandler {
-  constructor(sources, options) {
+  constructor(sources) {
     this._events = zip(
       fromEvent(sources, 'mouseover', { capture: true }),
       fromEvent(sources, 'mouseout', { capture: true }),
@@ -23,7 +23,7 @@ export default class HoverEventHandler {
         (leave.timeStamp - enter.timeStamp) > 100 &&
           isHoverable(enter.target);
       }),
-      map(([, leave]) => new ElementHovered(leave, options))
+      map(([, leave]) => {return {event: leave, processed: new ElementHovered(leave)};})
     );
   }
 

--- a/src/recorder/events/handlers/navigate-event-handler.js
+++ b/src/recorder/events/handlers/navigate-event-handler.js
@@ -7,7 +7,7 @@ export default class NavigateEventHandler {
     this._events = fromEvent(sources, 'popstate')
       .pipe(
         map((event) => {
-          return new BrowserHistoryChange(event);
+          return {event: event, processed: new BrowserHistoryChange(event)};
         })
       );
   }

--- a/src/recorder/events/value-entered.js
+++ b/src/recorder/events/value-entered.js
@@ -2,8 +2,8 @@ import eventTypes from './event-types';
 import Event from './event';
 
 export default class ValueEntered extends Event {
-  constructor(event, saveAllData, options) {
-    super(event, options);
+  constructor(event, saveAllData) {
+    super(event);
     const element = event.target;
 
     if (!element) {

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -68,7 +68,7 @@ function getLabelForElement(element) {
     let shortestDistance = null;
 
     if (element.getBoundingClientRect) {
-      const labelElements = document.querySelectorAll(LABEL_TAGS.join() + ',.label');
+      const labelElements = document.querySelectorAll(LABEL_TAGS.join() + ',div,.label');
 
       let possibleLabels = Array.from(labelElements)
         .filter(label => isVisible(label) && possiblyRelated(element, label) && label.innerText);

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -22,7 +22,10 @@ export default class Recorder {
       this.eventListener
         .events()
         .subscribe((event) => {
-          this.postNewEvent(event);
+          setTimeout(() => {
+            event.processed.calcAdditionalData(event.event, false);
+            this.postNewEvent(event.processed);
+          }, 0);
         });
     } else {
       this.subscribeToEventsPlugin();
@@ -48,17 +51,18 @@ export default class Recorder {
     this.eventSubscription = this.eventListener
       .events()
       .subscribe((event) => {
+        event.processed.calcAdditionalData(event.event, true);
         // Left for backward compability. Init
         const events = JSON.parse(localStorage.getItem(pluginSessionId) || '[]');
 
-        event.occurredAt = new Date();
-        events.push(event);
+        event.processed.occurredAt = new Date();
+        events.push(event.processed);
 
         localStorage.setItem(pluginSessionId, JSON.stringify(events));
         // Left for backward compability. End
 
         document.dispatchEvent(new CustomEvent('newEventRecorded', {
-          detail: event
+          detail: event.processed
         }));
       });
   }


### PR DESCRIPTION
Moved expensive calculations to a separate function to call them asynchronously when the library is deployed.
Changed isContentEditable div handling to only send one request when the user finishes editing it.
Also added a small fix to an issue introduced in #70 where I removed `div` from `labelTags`