### PR TITLE
Shadow DOM improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.35",
+  "version": "0.0.48",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -10,7 +10,7 @@ import {
 
 export default class Event {
   constructor(event) {
-    let element = event.target || event.toElement || event.srcElement;
+    let element = event.toElement || event.target || event.srcElement;
 
     element = this.skipSVGInternals(element);
 
@@ -51,8 +51,14 @@ export default class Event {
 
   calcAdditionalData(event, calculateContext) {
     if (event.type !== 'popstate') {
-      let element = event.target || event.toElement || event.srcElement,
+      let element = event.toElement || event.target || event.srcElement,
         isClick = event.type === 'click';
+
+      element = this.skipSVGInternals(element);
+
+      if (!element) {
+        return;
+      }
 
       let labelElement = getLabelForElement(element).label;
 
@@ -297,9 +303,12 @@ export default class Event {
   }
 
   hasPointerCursor(element) {
-    let style = window.getComputedStyle(element);
+    if (element !== null && element.nodeType === 1) {
+      let style = window.getComputedStyle(element);
 
-    return style && style.getPropertyValue('cursor') === 'pointer';
+      return style && style.getPropertyValue('cursor') === 'pointer';
+    }
+    return null;
   }
 
   skipSVGInternals(element) {


### PR DESCRIPTION
Prioritized `toElement` over `target`. In some cases, the actual element clicked is `toElement` instead of `target`, in most cases both properties are equal.
Only check computed style for node type elements. This was causing errors when trying to get computed style for document fragments.
Skip SVG internals when calculating complex event data (identifier, anchor, etc)