### PR TITLE
Miscellaneous fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -181,7 +181,7 @@ export default class Event {
     if (relatedLabel.highConfidence) {
       return relatedLabel.label.innerText;
     }
-    if (useInnerText && !isInput(srcElement) && srcElement.innerText) {
+    if (useInnerText && !isInput(srcElement) && srcElement.innerText && srcElement.innerText.trim()) {
       return srcElement.innerText;
     }
     if (srcElement.name) {
@@ -294,7 +294,9 @@ export default class Event {
 
     while (currentNode) {
       if (element !== currentNode && labelElement !== currentNode &&
-        !this.isContainedByOrContains(element, currentNode) && isPossiblyVisible(currentNode) &&
+        !this.isContainedByOrContains(element, currentNode) &&
+        (!labelElement || !this.isContainedByOrContains(labelElement, currentNode)) &&
+        isPossiblyVisible(currentNode) &&
         this.getIdentifier(currentNode, false, true, false).identifier === identifier) {
         return false;
       }

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -9,6 +9,10 @@ function possiblyRelated(element, label) {
     return isSwitch(element);
   }
 
+  if (!isInput(element)) {
+    return true;
+  }
+
   return labelRect.left <= (elementRect.left + (elementRect.width * 0.1)) && labelRect.top <= elementRect.bottom;
 }
 
@@ -21,6 +25,10 @@ function getRelatedLabel(element) {
 }
 
 function isLabelWithHighConfidence(element, labelElement, distance) {
+  if (!isInput(element)) {
+    return false;
+  }
+
   if (labelElement && distance) {
     let labelRect = labelElement.getBoundingClientRect();
 
@@ -43,13 +51,6 @@ function isLabelWithHighConfidence(element, labelElement, distance) {
 
 function getLabelForElement(element) {
   try {
-    if (!isInput(element)) {
-      return {
-        label: null,
-        highConfidence: false
-      };
-    }
-
     let relatedLabel = getRelatedLabel(element);
 
     if (relatedLabel) {


### PR DESCRIPTION
A few small improvements:

* Reference elements: when checking if an element's identifier is unique, exclude elements that contain or are contained by the element label. This bug was causing us to add a reference element in situations where it isn't necessary.
* Labels: search for labels for non-input elements, but make them highConfidence = false. This allows us to pick up the label from dropdowns constructed with divs, and clicks on divs that contain a switch-label pair
* Descriptors: ignore innerText if only contains whitespace (it is going to be trimmed on the backend so we need to ignore it)