### PR TITLE
Remove legacy storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -74,13 +74,20 @@ function getLabelForElement(element) {
       let possibleLabels = Array.from(labelElements)
         .filter(label => isVisible(label) && possiblyRelated(element, label) && label.innerText);
 
-      for (const possibleLabel of possibleLabels) {
-        let distance = distanceBetweenLeftCenterPoints(element, possibleLabel);
+      if (possibleLabels.length) {
+        for (const possibleLabel of possibleLabels) {
+          let distance = distanceBetweenLeftCenterPoints(element, possibleLabel);
 
-        if (shortestDistance === null || distance < shortestDistance) {
-          shortestDistance = distance;
-          labelElement = possibleLabel;
+          if (shortestDistance === null || distance < shortestDistance) {
+            shortestDistance = distance;
+            labelElement = possibleLabel;
+          }
         }
+      } else {
+        return {
+          label: null,
+          highConfidence: false
+        };
       }
     }
     return {

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -51,6 +51,9 @@ export default class Recorder {
   }
 
   subscribeToEventsPlugin() {
+    // clear legacy storage, this is no longer needed as plugin handles it on its own
+    localStorage.removeItem(pluginSessionId);
+
     this.eventSubscription = this.eventListener
       .events()
       .subscribe((event) => {
@@ -58,14 +61,6 @@ export default class Recorder {
           return;
         }
         event.processed.calcAdditionalData(event.event, true);
-        // Left for backward compability. Init
-        const events = JSON.parse(localStorage.getItem(pluginSessionId) || '[]');
-
-        event.processed.occurredAt = new Date();
-        events.push(event.processed);
-
-        localStorage.setItem(pluginSessionId, JSON.stringify(events));
-        // Left for backward compability. End
 
         document.dispatchEvent(new CustomEvent('newEventRecorded', {
           detail: event.processed
@@ -89,17 +84,6 @@ export default class Recorder {
       }
     }
     return true;
-  }
-
-  // Left for backward compatibility
-  stopRecording() {
-    const events = JSON.parse(localStorage.getItem(pluginSessionId) || '[]');
-
-    localStorage.removeItem(pluginSessionId);
-
-    document.dispatchEvent(new CustomEvent('recordingStopped', {
-      detail: events
-    }));
   }
 
   restartWithConfig(config) {


### PR DESCRIPTION
Remove legacy code on start/stop that used storage. Storage is managed by the plugin now and this was causing us to keep adding useless data on storage without using or cleaning it

Added a small fix to not return label if there are no possible label element matches