### PR TITLE
Performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -71,12 +71,15 @@ export default class Event {
         this.customTag = this.getNearestCustomTag(element);
       }
 
-      let isNotClickOfInput = isClick && !isInput(element);
+      let isNotClickOfInput = isClick && !isInput(element),
+        isHover = event.type === 'mouseout';
 
-      let identifyingData = this.getIdentifier(element, false, isNotClickOfInput, calculateContext, labelElement);
+      let identifyingData = this.getIdentifier(element, false, isNotClickOfInput,
+        !isHover && calculateContext, labelElement);
 
       if (!identifyingData.identifier) {
-        identifyingData = this.getIdentifier(element, true, isNotClickOfInput, calculateContext, labelElement);
+        identifyingData = this.getIdentifier(element, true, isNotClickOfInput,
+          !isHover && calculateContext, labelElement);
       }
 
       this.identifier = identifyingData.identifier;
@@ -366,10 +369,11 @@ export default class Event {
 
   getAnchorElement(element, identifier) {
     // find elements with different identifiers
-    let queryRoot = this.getXPathForElement(this.get10thAncestor(element)) || '/body',
+    let tenthAncestor = this.get10thAncestor(element),
+      queryRoot = this.getXPathForElement(tenthAncestor) || '/body',
       query = `${queryRoot}//*[not(contains(normalize-space(), ${cleanupQuotes(identifier)}))]` +
-        attrNonMatch(identifier, queryRoot),
-      differentIdNodes = document.evaluate(query, document, null, XPathResult.ANY_TYPE, null),
+          attrNonMatch(identifier, queryRoot),
+      differentIdNodes = document.evaluate(query, tenthAncestor, null, XPathResult.ANY_TYPE, null),
       currentDiffNode = differentIdNodes.iterateNext(),
       shortestDistance = null,
       anchorElement = null;

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -1,5 +1,5 @@
 import {zip, fromEvent} from 'rxjs';
-import {map, filter} from 'rxjs/operators';
+import {map, filter, throttleTime} from 'rxjs/operators';
 import ElementHovered from '../element-hovered';
 
 function isHoverable(element) {
@@ -20,9 +20,10 @@ export default class HoverEventHandler {
     ).pipe(
       filter(([enter, leave]) => {
         return enter.target === leave.target &&
-        (leave.timeStamp - enter.timeStamp) > 100 &&
+        (leave.timeStamp - enter.timeStamp) > 250 &&
           isHoverable(enter.target);
       }),
+      throttleTime(500),
       map(([, leave]) => {return {event: leave, processed: new ElementHovered(leave)};})
     );
   }

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -60,11 +60,13 @@ export default class Recorder {
         if (event.processed.skipEvent) {
           return;
         }
-        event.processed.calcAdditionalData(event.event, true);
+        setTimeout(() => {
+          event.processed.calcAdditionalData(event.event, true);
 
-        document.dispatchEvent(new CustomEvent('newEventRecorded', {
-          detail: event.processed
-        }));
+          document.dispatchEvent(new CustomEvent('newEventRecorded', {
+            detail: event.processed
+          }));
+        }, 0);
       });
   }
 


### PR DESCRIPTION
- Do expensive calculations in a 0ms timeout for plugin too (we are doing it for deployed recordings already)
- Reduced scope of document.evaluate in anchor lookup
- Hovers: widened the hover window to 250ms, added throttle time of 500ms and stopped calculating context/anchors for them.