### PR TITLE
Faster uniqueness check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
We do a uniqueness check on the element's identifier to see if we need to add an anchor reference to the step.

This makes the check faster by:
- Matching only by normalized full text instead of using `contains`. Identifiers that only contain the event target identifier shouldn't even be considered, only full matches would make the identifier non-unique.
- if the event target identifier came from visible text, only look for other elements with matching visible text instead of also including elements with matching attrs like name, id, class, etc. Those elements won't matter because the visible text has a higher priority

The following screenshots show the difference before and after this fix. In both I recorded clicking on "Music" on the right of the page:

![Screenshot from 2021-02-05 16-16-10](https://user-images.githubusercontent.com/54808102/107084171-77c49900-67d5-11eb-93b3-32924bfa7d89.png)
![Screenshot from 2021-02-05 16-44-59](https://user-images.githubusercontent.com/54808102/107084166-76936c00-67d5-11eb-81a6-e8798ff0bf43.png)

