### PR TITLE
Select and labels fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -210,15 +210,15 @@ export default class Event {
         visibleText: true
       };
     }
-    if (srcElement.name) {
-      return {
-        value: srcElement.name,
-        visibleText: false
-      };
-    }
     if (srcElement.ariaLabel) {
       return {
         value: srcElement.ariaLabel,
+        visibleText: false
+      };
+    }
+    if (srcElement.name) {
+      return {
+        value: srcElement.name,
         visibleText: false
       };
     }

--- a/src/recorder/events/value-entered.js
+++ b/src/recorder/events/value-entered.js
@@ -12,18 +12,19 @@ export default class ValueEntered extends Event {
     this.placeholder = element.placeholder;
     this.name = element.name;
 
-    if (this.resourceId) {
-      try {
-        let query = document.querySelector(`[for=${this.resourceId}]`);
-
-        if (query) {
-          this.label = query.innerText;
-        }
-      } catch (error) {}
-    }
-
-    if (saveAllData === 'true' || saveAllData === true) {
+    if (saveAllData === true) {
       this.value = element.value || element.innerText;
+
+      if (element.tagName && element.tagName.toLowerCase() === 'select') {
+        for (let i = 0; i < element.children.length; i++) {
+          let option = element.children[i];
+
+          if (option.value === element.value && !!option.innerText) {
+            this.value = option.innerText;
+            break;
+          }
+        }
+      }
     }
     this.type = eventTypes.INPUT;
   }

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -30,6 +30,14 @@ function isLabelWithHighConfidence(element, labelElement, distance) {
   }
 
   if (labelElement && distance) {
+    if (labelElement.htmlFor && labelElement.htmlFor !== element.id) {
+      return false;
+    }
+
+    if (labelElement.innerText.contains('\n')) {
+      return false;
+    }
+
     let labelRect = labelElement.getBoundingClientRect();
 
     let elementRect = element.getBoundingClientRect();


### PR DESCRIPTION
When entering data into selects, use the visible text of the option instead of the value. 
Bumped aria-label priority as descriptor. Its meant to be readable while name can be a bad descriptor.
Labels: don't use a label that has a for attr pointing to a different input, and don't use multiline labels.