### PR TITLE
Support aria-referencedby labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -1,4 +1,4 @@
-import {fromEvent, merge, zip} from 'rxjs';
+import {fromEvent, merge, combineLatest} from 'rxjs';
 import {map, filter} from 'rxjs/operators';
 
 import ValueEntered from '../value-entered';
@@ -8,7 +8,7 @@ export default class InputEventHandler {
     this.saveAllData = options.saveAllData;
     this._events = merge(
       fromEvent(sources, 'change', { capture: true }),
-      zip(
+      combineLatest(
         fromEvent(sources, 'input', { capture: true }),
         fromEvent(sources, 'blur', { capture: true }),
       ).pipe(


### PR DESCRIPTION
Use an element's aria-referencedby elements as labels. ~Adapted identifier logic to acommodate for elements with multiple labels~
Also changed input event processing from zip to combineLatest because zip was linking events to the wrong element if two or more content-editable divs were edited in sequence

Edit: dropped multi-label approach because it was producing steps that we can't run properly. If an element has multiple ids in aria-labelledby attribute, we use those to search for the closest one that is related.