### PR TITLE
Salesforce improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -1,7 +1,9 @@
 import { getLabelForElement } from '../helpers/label-finder';
-import { HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
+import {
+  HTML_TAGS, INLINE_TAGS, CONSIDER_INNER_TEXT_TAGS,
   isInput, isButtonOrLink, isButton, LOG_OUT_IDENTIFIERS,
-  LOG_IN_IDENTIFIERS } from '../helpers/html-tags';
+  LOG_IN_IDENTIFIERS, isLabel, hasChildren
+} from '../helpers/html-tags';
 import {isVisible, visualDistance, getRelation, isPossiblyVisible} from '../helpers/rect-helper';
 import {
   leafContainsLowercaseNormalizedMultiple, attrMatch,
@@ -426,8 +428,9 @@ export default class Event {
       shortestDistance = null,
       anchorElement = null;
 
-    while (currentDiffNode && ((shortestDistance == null) || (shortestDistance > 250))) {
-      if (isVisible(currentDiffNode) && currentDiffNode !== element &&
+    while (currentDiffNode) {
+      if ((isLabel(currentDiffNode) || isButtonOrLink(currentDiffNode)) && !hasChildren(currentDiffNode) &&
+        isVisible(currentDiffNode) && currentDiffNode !== element &&
         !this.isContainedByOrContains(currentDiffNode, element)) {
         let descriptor = this.getDescriptor(currentDiffNode, false, true).value;
 

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -2,6 +2,7 @@ import {fromEvent, merge, combineLatest} from 'rxjs';
 import {map, filter} from 'rxjs/operators';
 
 import ValueEntered from '../value-entered';
+import {isInput} from '../../helpers/html-tags';
 
 export default class InputEventHandler {
   constructor(sources, options) {
@@ -17,6 +18,7 @@ export default class InputEventHandler {
           input.target === blur.target),
         map(([, blur]) => blur)))
       .pipe(
+        filter((event) => isInput(event.target)),
         map((event) => {return {event: event, processed: new ValueEntered(event, this.saveAllData)};})
       );
   }

--- a/src/recorder/helpers/html-tags.js
+++ b/src/recorder/helpers/html-tags.js
@@ -48,8 +48,13 @@ module.exports.isLabel = function (element) {
   if (!element.tagName) {
     return false;
   }
-  return LABEL_TAGS.indexOf(element.tagName.toLowerCase()) !== -1 ||
-    (element.tagName.toLowerCase() === 'div' && !!element.innerText);
+  return !!element.innerText && ((LABEL_TAGS.indexOf(element.tagName.toLowerCase()) !== -1) ||
+    (element.tagName.toLowerCase() === 'div'));
+};
+
+module.exports.hasChildren = function (element) {
+  return element.children.length ||
+      (element.shadowRoot && element.shadowRoot.children.length);
 };
 
 module.exports.LOG_OUT_IDENTIFIERS = ['logout', 'log out', 'signout', 'sign out', 'log me out', 'sign me out'];

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -21,7 +21,10 @@ function getRelatedLabel(element) {
     return '';
   }
 
-  return document.querySelector(`label[for="${element.id}"]`);
+  let relatedLabel = document.evaluate(`//label[@for='${element.id}']`, document,
+    null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+
+  return relatedLabel.singleNodeValue;
 }
 
 function getLabelledByLabels(element) {

--- a/src/recorder/helpers/rect-helper.js
+++ b/src/recorder/helpers/rect-helper.js
@@ -239,12 +239,14 @@ function isNodeContainsOther(parent, child) {
 
 function isPossiblyVisible(node) {
   let rect = getRect(node),
-    style = window.getComputedStyle(node);
+    style = window.getComputedStyle(node),
+    clip = style.getPropertyValue('clip');
 
   return !!(node.offsetWidth || node.offsetHeight ||
     (node.getClientRects() && node.getClientRects().length)) &&
     style.getPropertyValue('visibility') !== 'hidden' &&
-    rect.height >= 1 && rect.width >= 1;
+    rect.height >= 1 && rect.width >= 1 &&
+    clip !== 'rect(0px, 0px, 0px, 0px)';
 }
 
 function isVisible(node) {


### PR DESCRIPTION
- Visibility check accounts for elements hidden with css clip with 0px rect
- Change label[for] lookup to use document evaluate instead of querySelector. QuerySelector isn't finding elements that are on the page, might be because they are in different document-fragments
- Anchor lookup only uses labels buttons or links with no children.
- Ignore data entry events from elements that are not inputs.