### PR TITLE
Fix recording from inputs with custom events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/browser-history-change.js
+++ b/src/recorder/events/browser-history-change.js
@@ -4,7 +4,7 @@ import Event from './event';
 export default class BrowserHistoryChange extends Event {
 
   constructor(event) {
-    super(event);
+    super(event, true);
     this.type = eventTypes.BROWSER_HISTORY_CHANGE;
   }
 };

--- a/src/recorder/events/element-clicked.js
+++ b/src/recorder/events/element-clicked.js
@@ -4,7 +4,7 @@ import Event from './event';
 export default class ElementClicked extends Event {
 
   constructor(event, doubleClick) {
-    super(event);
+    super(event, true);
 
     const element = event['srcElement'];
 

--- a/src/recorder/events/element-dragged.js
+++ b/src/recorder/events/element-dragged.js
@@ -3,7 +3,7 @@ import Event from './event';
 
 export default class ElementDragged extends Event {
   constructor(from, to) {
-    super(from);
+    super(from, true);
     this.type = eventTypes.DRAG_AND_DROP;
     this.dragX = from.clientX;
     this.dragY = from.clientY;

--- a/src/recorder/events/element-hovered.js
+++ b/src/recorder/events/element-hovered.js
@@ -3,7 +3,7 @@ import Event from './event';
 
 export default class ElementHovered extends Event {
   constructor(event) {
-    super(event);
+    super(event, true);
     this.type = eventTypes.HOVER;
   }
 };

--- a/src/recorder/events/element-scrolled.js
+++ b/src/recorder/events/element-scrolled.js
@@ -3,7 +3,7 @@ import Event from './event';
 
 export default class ElementScrolled extends Event {
   constructor(event, down) {
-    super(event);
+    super(event, true);
     this.type = eventTypes.SCROLL;
     this.down = down;
   }

--- a/src/recorder/events/enter-key-pressed.js
+++ b/src/recorder/events/enter-key-pressed.js
@@ -3,7 +3,7 @@ import Event from './event';
 
 export default class EnterKeyPressed extends Event {
   constructor(event) {
-    super(event);
+    super(event, true);
     this.type = eventTypes.ENTER_KEY_PRESS;
   }
 };

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -11,9 +11,17 @@ import {
 } from '../helpers/query-helper';
 
 export default class Event {
-  constructor(event) {
-    let element = event.toElement || event.target || event.srcElement;
+  constructor(event, init) {
+    if (!init) {
+      return;
+    }
 
+    let element = this.getTarget(event);
+
+    this.init(element);
+  }
+
+  init(element) {
     element = this.skipSVGInternals(element);
 
     if (!element) {
@@ -52,9 +60,34 @@ export default class Event {
     this.url = location.href;
   }
 
+  getTarget(event) {
+    let native = event.toElement || event.target || event.srcElement;
+
+    if ((event.type !== 'change') || isInput(native)) {
+      return native;
+    }
+
+    let path = event.composedPath && event.composedPath();
+
+    let first = (path && path[0]) ? path[0] : null;
+
+    if (first) {
+      if (isInput(first)) {
+        return first;
+      }
+      let inputChild = first.shadowRoot ?
+        first.shadowRoot.querySelector('input') : first.querySelector('input');
+
+      if (inputChild) {
+        return inputChild;
+      }
+    }
+    return null;
+  }
+
   calcAdditionalData(event, calculateContext) {
     if (event.type !== 'popstate') {
-      let element = event.toElement || event.target || event.srcElement,
+      let element = this.getTarget(event),
         isClick = event.type === 'click';
 
       element = this.skipSVGInternals(element);

--- a/src/recorder/events/handlers/input-event-handler.js
+++ b/src/recorder/events/handlers/input-event-handler.js
@@ -2,7 +2,6 @@ import {fromEvent, merge, combineLatest} from 'rxjs';
 import {map, filter} from 'rxjs/operators';
 
 import ValueEntered from '../value-entered';
-import {isInput} from '../../helpers/html-tags';
 
 export default class InputEventHandler {
   constructor(sources, options) {
@@ -18,7 +17,6 @@ export default class InputEventHandler {
           input.target === blur.target),
         map(([, blur]) => blur)))
       .pipe(
-        filter((event) => event.target && isInput(event.target)),
         map((event) => {return {event: event, processed: new ValueEntered(event, this.saveAllData)};})
       );
   }

--- a/src/recorder/events/value-entered.js
+++ b/src/recorder/events/value-entered.js
@@ -3,12 +3,16 @@ import Event from './event';
 
 export default class ValueEntered extends Event {
   constructor(event, saveAllData) {
-    super(event);
-    const element = event.target;
+    super(event, false);
 
-    if (!element) {
+    let element = this.getTarget(event);
+
+    this.init(element);
+
+    if (this.skipEvent) {
       return;
     }
+
     this.placeholder = element.placeholder;
     this.name = element.name;
 
@@ -28,5 +32,4 @@ export default class ValueEntered extends Event {
     }
     this.type = eventTypes.INPUT;
   }
-
 };


### PR DESCRIPTION
For custom change events where native target isn't the input, try to look for the input in the event's path and use that as target for our generated step.