### PR TITLE
Make uniqueness checks case insensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/query-helper.js
+++ b/src/recorder/helpers/query-helper.js
@@ -32,5 +32,31 @@ function attrMatchMultiple(attrValues = []) {
   return attrValues.map((value) => attrMatch(value)).join(' | ');
 }
 
+function getIgnoreCaseTranslation(searchTerm, searchIn = '.') {
+  if (!searchTerm) {
+    return '';
+  }
+
+  let cleanSearchTerm = searchTerm.replace("'", '').replace(/\s/g, ''),
+    lowerAlphabet = cleanSearchTerm.toLowerCase(),
+    upperAlphabet = cleanSearchTerm.toUpperCase();
+
+  return `translate(${searchIn}, '${upperAlphabet}', '${lowerAlphabet}')`;
+}
+
+function elementQuery(descriptor, visibleTextOnly) {
+  let text = getIgnoreCaseTranslation(descriptor, 'normalize-space(.)');
+
+  return `//*[${text} = ${cleanupQuotes(descriptor.toLowerCase())}]` +
+      (visibleTextOnly ? '' : ` | ${attrMatch(descriptor)}`);
+}
+
+function nonContainsQuery(descriptor, queryRoot = '//*/body') {
+  let text = getIgnoreCaseTranslation(descriptor, 'normalize-space(.)');
+
+  return `${queryRoot}//*[not(contains(${text}, ${cleanupQuotes(descriptor)}))]` +
+    attrNonMatch(descriptor, queryRoot);
+}
+
 export { leafContainsLowercaseNormalized, leafContainsLowercaseNormalizedMultiple,
-  attrMatch, attrMatchMultiple, attrNonMatch, cleanupQuotes };
+  attrMatch, attrMatchMultiple, attrNonMatch, cleanupQuotes, elementQuery, nonContainsQuery };


### PR DESCRIPTION
XPath queries don't have a built in way to do case insensitive checks, the best way to do this currently is using `translate`
Added a minor fix: don't consider element "label" during uniqueness check if the element is a button or link