### PR TITLE
Fix use of the element's parent's identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -184,7 +184,7 @@ export default class Event {
     if (!identifierText && !isInput(element)) {
       identifiedElement = this.getIdentifiableParent(element, '', 10,
         useClass, isNotClickOfInput, this.hasPointerCursor(element), useInnerText);
-      descriptor = this.getDescriptor(element, useClass, useInnerText);
+      descriptor = this.getDescriptor(identifiedElement, useClass, useInnerText);
       identifierText = descriptor.value.trim();
       isVisibleText = descriptor.visibleText;
     }


### PR DESCRIPTION
When a click is triggered from one of the button's internals (the svg icon in this case) we look for the containing button to find a suitable identifier. 
We were doing that but not actually using it because of this bug.