### PR TITLE
Reference elements for elements without identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
When a target element has no usable identifiers we are currently using xpaths. The goal of this PR is to make it so we use `click|enter into <ordinal> button|edit|element <reference element>` steps instead. For example: `click 2nd button below "some reference"`

For this we need to:
1. Find a close element with a unique identifier to use as anchor.
2. Determine the positional relation between the element and the anchor (above, below, left, right, etc)
3. Determine the area where all elements with the same positional relation have to be located.
4. Count how many other elements of the same type (button, edit, generic element) are present in that area.
5. Keep our element's index among all elements in the area.