### PR TITLE
Make sure the anchor reference is unique

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
I came up with two approaches for this:
1. while iterating over possible anchor elements, check if their identifier is unique, ignore the ones where it isn't
2. chose an anchor normally and then check if its unique, repeat the process until it is.

I decided to implement 2 because its safe to assume that in most cases the chosen anchor will be unique, so we save a ton of uniqueness checks that can be costly. Only when the chosen anchor is not unique we then perform the extra work needed.