### PR TITLE
Ignore non visible elements when looking for a generic anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -528,7 +528,7 @@ export default class Event {
       anchorIdentifier;
 
     while (current) {
-      if (!this.isContainedByOrContains(current, element)) {
+      if (isVisible(current) && !this.isContainedByOrContains(current, element)) {
         let distance = visualDistance(element, current);
 
         if ((!currentDistance || distance < currentDistance)) {


### PR DESCRIPTION
When trying to look for an anchor for an element without identifier, we can run into `<script>` tags which cause errors when trying to get identifiers from.
Ignoring all non-visible elements fixes this issue and improves processing, it doesn't make sense to use non-visible elements as anchors.