### PR TITLE
Don't init any fields other than url for popstate events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/browser-history-change.js
+++ b/src/recorder/events/browser-history-change.js
@@ -4,7 +4,10 @@ import Event from './event';
 export default class BrowserHistoryChange extends Event {
 
   constructor(event) {
-    super(event, true);
+    super(event, false);
+
+    this.url = location.href;
+
     this.type = eventTypes.BROWSER_HISTORY_CHANGE;
   }
 };


### PR DESCRIPTION
Usually those fields are null or identified in the event but in some cases they have arbitrary values that break our parsing/processing. 
With this we only get the url which is the only thing we need from `popstate` events.