### PR TITLE
Restart recorder when any listener is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event-listener.js
+++ b/src/recorder/events/event-listener.js
@@ -1,5 +1,5 @@
 import {from} from 'rxjs';
-import { publish, mergeAll} from 'rxjs/operators';
+import { publish, mergeAll } from 'rxjs/operators';
 
 import {ClickEventHandler, InputEventHandler, DragEventHandler, NavigateEventHandler, EnterKeyPressEventHandler,
   HoverEventHandler, DoubleClickEventHandler, ScrollEventHandler} from './handlers';
@@ -34,9 +34,14 @@ export default class EventListener {
     this._events = from(eventSources)
       .pipe(mergeAll(), publish());
     this._events.connect();
+    this._documents = documents;
   }
 
   events() {
     return this._events;
+  }
+
+  documents() {
+    return this._documents;
   }
 };

--- a/src/recorder/recorder.js
+++ b/src/recorder/recorder.js
@@ -68,6 +68,17 @@ export default class Recorder {
           }));
         }, 0);
       });
+    let recorder = this;
+
+    this.eventListener.documents().forEach((doc) => {
+      let current = doc.removeEventListener;
+
+      doc.removeEventListener = function (type, listener) {
+        current(type, listener);
+        setTimeout(() => recorder.restartWithConfig(recorder.config), 100);
+        doc.removeEventListener = current;
+      };
+    });
   }
 
   static shouldDispatchEvents(config) {


### PR DESCRIPTION
When the plugin is started/restarted, add a restart call to the document's `removeEventListener` call so if our listeners are removed the plugin is restarted, adding our listeners again.

To prevent this from hanging the browser or resetting unnecessarily, it leaves `removeEventListener` as it was and runs our restart after a small delay. This is necessary because if all of our listeners are removed at once (click, input, scroll, etc) then `removeEventListener` is going to be called once per each type of event, but we only need to reset our recorder _once_ after all the listeners are removed.