### PR TITLE
Remove whitespace and asterisks before and after labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -104,7 +104,7 @@ export default class Event {
       let labelElement = getLabelForElement(element).label;
 
       if (labelElement) {
-        this.label = labelElement.innerText;
+        this.label = this.stripAsteriskAndTrim(labelElement.innerText);
       }
 
       if (this.shouldCheckForCustomTag()) {
@@ -241,6 +241,13 @@ export default class Event {
     return identifyingData;
   }
 
+  stripAsteriskAndTrim(label) {
+    if (!label) {
+      return '';
+    }
+    return label.replace(/^\s*\**\s*|\s*\**\s*$/g, '');
+  }
+
   getLabelText(label) {
     let textNodes = [];
 
@@ -273,7 +280,7 @@ export default class Event {
 
     if (relatedLabel.highConfidence) {
       return {
-        value: this.getLabelText(relatedLabel.label),
+        value: this.stripAsteriskAndTrim(this.getLabelText(relatedLabel.label)),
         visibleText: true
       };
     }


### PR DESCRIPTION
Simple regex replace that looks for leading or trailing blocks of: zero or more whitespace characters followed by zero or more asterisks followed by zero or more whitespace characters. Search is global so it can remove leading and trailing blocks in the same call