### PR TITLE
Do not open browser when starting, allow requests from all hosts to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx webpack --config webpack.config.js --mode=production --env.RECORDER_URL='https://recorder.testrigor.com'",
     "dev": "npx webpack --progress --colors --watch --mode development",
-    "start": "npx webpack-dev-server --open --mode development --env.RECORDER_URL=http://localhost:8085"
+    "start": "npx webpack-dev-server --mode development --env.RECORDER_URL=http://localhost:8085 --disable-host-check"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
1) Do not open browser when starting

2) Allow requests from all hosts to fix "Invalid Host Header” error

Ticket: https://www.pivotaltracker.com/n/projects/1526511/stories/174975171

Appkong PR: https://github.com/TestRigor/appkong/pull/1135
Combinator PR: https://github.com/TestRigor/combinator/pull/1764
Recorder Service PR: https://github.com/TestRigor/recorder-service/pull/49
Recorder PR: https://github.com/TestRigor/recorder/pull/25