### PR TITLE
Add an event that triggers when selecting text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event-listener.js
+++ b/src/recorder/events/event-listener.js
@@ -2,7 +2,8 @@ import {from} from 'rxjs';
 import { publish, mergeAll } from 'rxjs/operators';
 
 import {ClickEventHandler, InputEventHandler, DragEventHandler, NavigateEventHandler, EnterKeyPressEventHandler,
-  HoverEventHandler, DoubleClickEventHandler, ScrollEventHandler, SubmitEventHandler} from './handlers';
+  HoverEventHandler, DoubleClickEventHandler, ScrollEventHandler, SubmitEventHandler,
+  TextSelectedEventHandler} from './handlers';
 
 export default class EventListener {
   constructor(options, dispatchEvents) {
@@ -30,6 +31,7 @@ export default class EventListener {
 
     if (!dispatchEvents) {
       eventSources.push((new HoverEventHandler(documents)).events);
+      eventSources.push((new TextSelectedEventHandler(documents)).events);
     }
 
     this._events = from(eventSources)

--- a/src/recorder/events/event-types.js
+++ b/src/recorder/events/event-types.js
@@ -6,7 +6,8 @@ const eventTypes = {
   ENTER_KEY_PRESS: 'enterKeyPress',
   HOVER: 'hover',
   SCROLL: 'scroll',
-  SUBMIT: 'submit'
+  SUBMIT: 'submit',
+  TEXT_SELECTION: 'textSelected'
 };
 
 export default eventTypes;

--- a/src/recorder/events/handlers/click-event-handler.js
+++ b/src/recorder/events/handlers/click-event-handler.js
@@ -1,13 +1,23 @@
-import {fromEvent} from 'rxjs';
-import {map, throttleTime} from 'rxjs/operators';
+import {fromEvent, zip} from 'rxjs';
+import {filter, map, throttleTime} from 'rxjs/operators';
 import ElementClicked from '../element-clicked';
 
 export default class ClickEventHandler {
   constructor(sources) {
-    this._events = fromEvent(sources, 'click', { capture: true })
+    this._events = zip(
+      fromEvent(sources, 'mousedown', { capture: true }),
+      fromEvent(sources, 'mouseup', { capture: true }),
+      fromEvent(sources, 'click', { capture: true })
+    )
       .pipe(
         throttleTime(200),
-        map((event) => {return {event: event, processed: new ElementClicked(event, false)};})
+        filter(([mousedown, mouseup]) => {
+          let absMouseMovement = Math.abs(mousedown.clientX - mouseup.clientX) +
+            Math.abs(mousedown.clientY - mouseup.clientY);
+
+          return absMouseMovement <= 50;
+        }),
+        map(([,, click]) => {return {event: click, processed: new ElementClicked(click, false)};})
       );
   }
 

--- a/src/recorder/events/handlers/index.js
+++ b/src/recorder/events/handlers/index.js
@@ -7,6 +7,7 @@ import HoverEventHandler from './hover-event-handler';
 import DoubleClickEventHandler from './doubleclick-event-handler';
 import ScrollEventHandler from './scroll-event-handler';
 import SubmitEventHandler from './submit-event-handler';
+import TextSelectedEventHandler from './text-selected-event-handler';
 
 export {ClickEventHandler, InputEventHandler, DragEventHandler, NavigateEventHandler, EnterKeyPressEventHandler,
-  HoverEventHandler, DoubleClickEventHandler, ScrollEventHandler, SubmitEventHandler};
+  HoverEventHandler, DoubleClickEventHandler, ScrollEventHandler, SubmitEventHandler, TextSelectedEventHandler};

--- a/src/recorder/events/handlers/text-selected-event-handler.js
+++ b/src/recorder/events/handlers/text-selected-event-handler.js
@@ -1,0 +1,36 @@
+import {fromEvent, zip} from 'rxjs';
+import {filter, map} from 'rxjs/operators';
+import TextSelected from '../text-selected';
+
+export default class TextSelectedEventHandler {
+  constructor(sources) {
+    function getSelectedText() {
+      let text = '';
+
+      if (window.getSelection) {
+        text = window.getSelection().toString();
+      } else if (document.selection && document.selection.type !== 'Control') {
+        text = document.selection.createRange().text;
+      }
+      return text;
+    }
+
+    this._events = zip(
+      fromEvent(sources, 'mousedown', { capture: true }),
+      fromEvent(sources, 'mouseup', { capture: true }),
+    )
+      .pipe(
+        filter(([mousedown, mouseup]) => {
+          let absMouseMovement = Math.abs(mousedown.clientX - mouseup.clientX) +
+            Math.abs(mousedown.clientY - mouseup.clientY);
+
+          return !!getSelectedText() && absMouseMovement > 50;
+        }),
+        map(([, mouseup]) => {return {event: mouseup, processed: new TextSelected(mouseup, getSelectedText())};})
+      );
+  }
+
+  get events() {
+    return this._events;
+  }
+};

--- a/src/recorder/events/text-selected.js
+++ b/src/recorder/events/text-selected.js
@@ -1,0 +1,12 @@
+import eventTypes from './event-types';
+import Event from './event';
+
+export default class TextSelected extends Event {
+
+  constructor(event, text) {
+    super(event, true);
+
+    this.type = eventTypes.TEXT_SELECTION;
+    this.value = text;
+  }
+};


### PR DESCRIPTION
Listen to mouseup events to capture text selection. 
Since regular clicks also trigger mouseup events, only get selected text when the total distance between the cursor's initial position (mousedown) and final position (mouseup) is greater than 50, and only capture clicks when that distance is smaller or equal to 50.
This has the side effect that some clicks that have an effect on the page may not be captured if the user drags the mouse between pressing and releasing the mouse click.


https://user-images.githubusercontent.com/54808102/170079296-cd4dbde0-a43d-4732-a8b2-d74681eed333.mp4

