### PR TITLE
Label confidence: only check for linebreaks for non label tags and after trimming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/helpers/label-finder.js
+++ b/src/recorder/helpers/label-finder.js
@@ -46,7 +46,7 @@ function isLabelWithHighConfidence(element, labelElement, distance) {
       return false;
     }
 
-    if (labelElement.innerText.includes('\n')) {
+    if ((labelElement.tagName !== 'LABEL') && labelElement.innerText.trim().includes('\n')) {
       return false;
     }
 


### PR DESCRIPTION
After getting the closest text element to the input, we assess if it is the element's label with high confidence or not based on a few checks. We were considering multi line text elements as low confidence, to avoid considering random paragraphs as high confidence labels.
This makes it so the multi line check is only made for elements that are not html labels, and after trimming to ignore trailing line breaks.

![Screenshot from 2022-06-15 15-07-22](https://user-images.githubusercontent.com/54808102/173896219-79db33fa-fda1-4557-9af1-9823a2aa951f.png)
![Screenshot from 2022-06-15 12-15-42](https://user-images.githubusercontent.com/54808102/173896227-8d6f0cd5-903a-4322-a458-297eeffd8410.png)