### PR TITLE
Hover improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-recorder",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/recorder/events/event.js
+++ b/src/recorder/events/event.js
@@ -66,7 +66,7 @@ export default class Event {
   }
 
   getTarget(event) {
-    let native = event.toElement || event.target || event.srcElement;
+    let native = event.target || event.toElement || event.srcElement;
 
     let path = event.composedPath && event.composedPath();
 
@@ -233,8 +233,8 @@ export default class Event {
 
     if (!identifierText && !isInput(element)) {
       identifiedElement = this.getIdentifiableParent(element, '', 10,
-        useClass, isNotClickOfInput, this.hasPointerCursor(element), useInnerText);
-      descriptor = this.getDescriptor(identifiedElement, useClass, useInnerText);
+        useClass, isNotClickOfInput, this.hasPointerCursor(element), false);
+      descriptor = this.getDescriptor(identifiedElement, useClass, false);
       identifierText = descriptor.value.trim();
       isVisibleText = descriptor.visibleText;
     }

--- a/src/recorder/events/handlers/hover-event-handler.js
+++ b/src/recorder/events/handlers/hover-event-handler.js
@@ -1,13 +1,25 @@
 import {zip, fromEvent} from 'rxjs';
 import {map, filter, throttleTime} from 'rxjs/operators';
 import ElementHovered from '../element-hovered';
+import {isVisible} from '../../helpers/rect-helper';
 
 function isHoverable(element) {
-  while (element) {
-    if (element.tagName && element.tagName.toLowerCase().includes('nav')) {
+  let count = 0;
+
+  while (element && count < 10) {
+    let attrs = [element.className && typeof element.className === 'string' ? element.className : '',
+      element.tagName, element.name, element.id];
+
+    if (attrs.map((attr) => attr ? attr.toLowerCase() : '').some((attr) => attr.includes('nav') ||
+      attr.includes('hover') || attr.includes('menu')) && isVisible(element)) {
       return true;
     }
     element = element.parentNode;
+    if (element && element.host) {
+      // if an element's parent is a document-fragment skip to its host
+      element = element.host;
+    }
+    count++;
   }
   return false;
 }
@@ -20,7 +32,7 @@ export default class HoverEventHandler {
     ).pipe(
       filter(([enter, leave]) => {
         return enter.target === leave.target &&
-        (leave.timeStamp - enter.timeStamp) > 250 &&
+        (leave.timeStamp - enter.timeStamp) > 500 &&
           isHoverable(enter.target);
       }),
       throttleTime(500),


### PR DESCRIPTION
- Look for hover related keywords on attributes other than class (id, name, tagName) and added a few keywords.
- Prioritized event.target over event.toElement for all events. toElement is non standard and it was pointing to the wrong element on some hovers.
- Don't look at innerText when trying to find a parent with good identifiers (often when the element hovered doesn't have a good identifier we go up the hierarchy trying to find a suitable element, but using innerText would cause it to choose the container with the entire menu as identifier, which doesn't work in combinator)
- Raised how long the hover has to be to be recorded because keyword changes might cause us to record more unwanted hovers.